### PR TITLE
Add validated patterns and debugging guides to develop plugin skills 

### DIFF
--- a/skills/fiftyone-develop-plugin/EXECUTION-STORE.md
+++ b/skills/fiftyone-develop-plugin/EXECUTION-STORE.md
@@ -1,0 +1,390 @@
+# Execution Store Patterns
+
+## Contents
+- [Overview](#overview)
+- [Store Key Strategy](#store-key-strategy)
+- [ExecutionStore API](#executionstore-api)
+- [Caching Patterns](#caching-patterns)
+- [State Management](#state-management)
+- [Cache Invalidation](#cache-invalidation)
+- [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+### Panel State vs Execution Store
+
+| Storage | Lifetime | Use Case |
+|---------|----------|----------|
+| `ctx.panel.state` | Transient (resets on panel reload) | UI state, form values, selected tabs |
+| `ctx.panel.data` | Transient (resets on panel reload) | Large data for plots, tables |
+| `ctx.store()` | Persistent (survives sessions) | User configs, cached results, execution history |
+
+```python
+def on_load(self, ctx):
+    # Transient: UI preferences
+    ctx.panel.state.active_tab = "overview"
+    ctx.panel.state.is_expanded = True
+
+    # Transient: Plot data
+    ctx.panel.data.chart_data = compute_chart_data(ctx.dataset)
+
+    # Persistent: User configuration
+    store = ctx.store(self._get_store_key(ctx))
+    ctx.panel.state.config = store.get("user_config") or default_config()
+```
+
+---
+
+## Store Key Strategy
+
+Use namespaced keys to avoid conflicts between plugins and datasets:
+
+```python
+class MyPanel(foo.Panel):
+    version = "v1"  # For migration support
+
+    def _get_store_key(self, ctx):
+        """Generate unique store key for this panel instance."""
+        plugin_name = self.config.name.split("/")[-1]
+        dataset_id = ctx.dataset._doc.id
+        return f"{plugin_name}_store_{dataset_id}_{self.version}"
+
+    def on_load(self, ctx):
+        store = ctx.store(self._get_store_key(ctx))
+        # ...
+```
+
+**Key components:**
+- **Plugin name**: Extracted from config, avoids hardcoding
+- **Dataset ID**: Prevents cross-dataset conflicts
+- **Version**: Enables migration when schema changes
+
+---
+
+## ExecutionStore API
+
+```python
+store = ctx.store("my_store")
+
+# Basic operations
+value = store.get(key)                    # Returns value or None
+store.set(key, value)                     # Persist (default policy)
+store.set(key, value, ttl=3600)           # Expire in 1 hour
+store.set(key, value, policy="evict")     # Can be cleared by clear_cache()
+store.set_cache(key, value, ttl=3600)     # Convenience for evict policy
+
+# Check and delete
+exists = store.has(key)                   # Returns bool
+deleted = store.delete(key)               # Returns bool
+
+# List and clear
+keys = store.list_keys()                  # Returns list of keys
+store.clear()                             # Delete all keys
+store.clear_cache()                       # Clear only evictable keys
+
+# TTL and policy management
+store.update_ttl(key, new_ttl)            # Update expiration
+store.update_policy(key, "persist")       # Change eviction policy
+
+# Metadata
+metadata = store.get_metadata(key)        # {created_at, updated_at, expires_at}
+
+# Real-time updates
+subscription_id = store.subscribe(callback)
+store.unsubscribe(subscription_id)
+```
+
+---
+
+## Caching Patterns
+
+### Template File Caching
+
+Cache expensive file loads with modification time tracking:
+
+```python
+def _load_template(self, ctx, template_path):
+    """Load template with caching based on file modification time."""
+    store = ctx.store(self._get_store_key(ctx))
+    cache_key = f"template_{hash(template_path)}"
+    cached = store.get(cache_key)
+
+    # Check if file has changed
+    file_mtime = os.path.getmtime(template_path)
+    if cached and cached.get("file_mtime") == file_mtime:
+        return cached.get("data")
+
+    # Load and cache
+    with open(template_path, "r") as f:
+        data = json.load(f)
+
+    store.set(cache_key, {
+        "data": data,
+        "file_mtime": file_mtime,
+        "cached_at": time.time(),
+    })
+    return data
+```
+
+### Computed Results Caching
+
+Cache expensive computations with dependency tracking:
+
+```python
+def _get_statistics(self, ctx, params):
+    """Get statistics with caching based on parameters."""
+    store = ctx.store(self._get_store_key(ctx))
+
+    # Create cache key from parameters
+    params_hash = hash(json.dumps(params, sort_keys=True))
+    cache_key = f"stats_{params_hash}"
+    cached = store.get(cache_key)
+
+    # Check if cache is still valid
+    if cached and self._is_cache_valid(cached, ctx):
+        return cached.get("result")
+
+    # Compute and cache
+    result = expensive_computation(ctx.dataset, params)
+
+    store.set(cache_key, {
+        "result": result,
+        "params": params,
+        "dataset_size": len(ctx.dataset),
+        "cached_at": time.time(),
+    })
+    return result
+
+def _is_cache_valid(self, cached, ctx):
+    """Check if cache is still valid based on dataset changes."""
+    cached_size = cached.get("dataset_size", 0)
+    current_size = len(ctx.dataset)
+
+    # Invalidate if dataset size changed significantly (>5%)
+    if abs(current_size - cached_size) > cached_size * 0.05:
+        return False
+
+    return True
+```
+
+---
+
+## State Management
+
+### Robust State Saving
+
+Validate before saving to prevent corruption:
+
+```python
+def _save_state(self, ctx):
+    """Save state with validation."""
+    store = ctx.store(self._get_store_key(ctx))
+
+    content = {
+        "config": ctx.panel.state.config,
+        "preferences": ctx.panel.state.preferences,
+        "version": self.version,
+        "saved_at": time.time(),
+    }
+
+    # Ensure JSON serializability
+    try:
+        json.dumps(content)
+        store.set("panel_state", content)
+    except (TypeError, ValueError) as e:
+        print(f"Warning: Could not save state: {e}")
+```
+
+### State Migration
+
+Handle version changes gracefully:
+
+```python
+def _load_state(self, ctx):
+    """Load state with version migration."""
+    store = ctx.store(self._get_store_key(ctx))
+    content = store.get("panel_state")
+
+    if content is None:
+        return self._default_state()
+
+    # Migrate if version changed
+    stored_version = content.get("version", "v0")
+    if stored_version != self.version:
+        content = self._migrate_state(content, stored_version)
+
+    return content
+
+def _migrate_state(self, content, from_version):
+    """Migrate state between versions."""
+    if from_version == "v0" and self.version == "v1":
+        # Add new field with default
+        content.setdefault("config", {})["new_option"] = "default"
+
+    content["version"] = self.version
+    return content
+```
+
+### Conditional State Loading
+
+Load state based on conditions:
+
+```python
+def on_load(self, ctx):
+    """Load state conditionally."""
+    if ctx.dataset is None:
+        return
+
+    store = ctx.store(self._get_store_key(ctx))
+    content = store.get("panel_state")
+
+    if content is None:
+        self._initialize_defaults(ctx)
+    elif self._should_reload(content, ctx):
+        self._initialize_smart_defaults(ctx, content)
+    else:
+        self._restore_state(ctx, content)
+
+def _should_reload(self, content, ctx):
+    """Check if state should be reloaded."""
+    # Reload if dataset changed significantly
+    stored_size = content.get("dataset_size", 0)
+    current_size = len(ctx.dataset)
+    return abs(current_size - stored_size) > stored_size * 0.1
+```
+
+---
+
+## Cache Invalidation
+
+### Pattern-Based Invalidation
+
+```python
+def _invalidate_cache(self, ctx, pattern=None):
+    """Invalidate cache entries matching pattern."""
+    store = ctx.store(self._get_store_key(ctx))
+
+    if pattern:
+        # Invalidate matching keys
+        for key in store.list_keys():
+            if pattern in key:
+                store.delete(key)
+    else:
+        # Clear all cache entries (keeping persistent data)
+        store.clear_cache()
+```
+
+### Time-Based Invalidation
+
+```python
+def _cleanup_old_cache(self, ctx, max_age_hours=24):
+    """Remove cache entries older than max_age."""
+    store = ctx.store(self._get_store_key(ctx))
+    cutoff_time = time.time() - (max_age_hours * 3600)
+
+    for key in store.list_keys():
+        metadata = store.get_metadata(key)
+        if metadata and metadata.get("updated_at", 0) < cutoff_time:
+            store.delete(key)
+```
+
+### Dataset-Aware Invalidation
+
+```python
+def on_change_dataset(self, ctx):
+    """Invalidate cache when dataset changes."""
+    store = ctx.store(self._get_store_key(ctx))
+
+    # Clear computed results that depend on dataset
+    for key in store.list_keys():
+        if key.startswith("stats_") or key.startswith("computed_"):
+            store.delete(key)
+```
+
+---
+
+## Best Practices
+
+### 1. Store Key Naming
+
+```python
+# Use descriptive prefixes
+"template_cache_{hash}"      # Cached templates
+"computed_stats_{params}"    # Computed results
+"user_config"                # User preferences
+"execution_history"          # Operation history
+```
+
+### 2. Include Metadata
+
+```python
+store.set(cache_key, {
+    "result": result,
+    "cached_at": time.time(),
+    "dataset_size": len(ctx.dataset),
+    "params": params,
+    "version": self.version,
+})
+```
+
+### 3. Error Handling
+
+```python
+def _safe_get(self, ctx, key, default=None):
+    """Safely get value with fallback."""
+    try:
+        store = ctx.store(self._get_store_key(ctx))
+        value = store.get(key)
+        return value if value is not None else default
+    except Exception as e:
+        print(f"Warning: Store access failed: {e}")
+        return default
+```
+
+### 4. Performance Considerations
+
+- Cache expensive operations (>100ms)
+- Use TTL for time-sensitive data
+- Implement cache size limits if needed
+- Clean up old entries periodically
+
+### 5. Security
+
+- Validate cached data before use
+- Consider data privacy implications
+- Use `clear()` when user requests data deletion
+
+---
+
+## Quick Reference
+
+```python
+class MyOperator(foo.Operator):
+    version = "v1"
+
+    def _get_store_key(self, ctx):
+        plugin_name = self.config.name.split("/")[-1]
+        return f"{plugin_name}_{ctx.dataset._doc.id}_{self.version}"
+
+    def execute(self, ctx):
+        store = ctx.store(self._get_store_key(ctx))
+
+        # Check cache
+        cached = store.get("result")
+        if cached and self._is_valid(cached, ctx):
+            return cached["result"]
+
+        # Compute
+        result = self._compute(ctx)
+
+        # Cache with metadata
+        store.set("result", {
+            "result": result,
+            "cached_at": time.time(),
+            "dataset_size": len(ctx.dataset),
+        })
+
+        return result
+```

--- a/skills/fiftyone-develop-plugin/HYBRID-PLUGINS.md
+++ b/skills/fiftyone-develop-plugin/HYBRID-PLUGINS.md
@@ -1,0 +1,559 @@
+# Hybrid Plugin Development (Python + JavaScript)
+
+## Contents
+- [When to Use Hybrid](#when-to-use-hybrid)
+- [Architecture Overview](#architecture-overview)
+- [Plugin Structure](#plugin-structure)
+- [Python Backend](#python-backend)
+- [TypeScript Frontend](#typescript-frontend)
+- [Communication Patterns](#communication-patterns)
+- [TypeScript Operators](#typescript-operators)
+- [Build Configuration](#build-configuration)
+- [Complete Example](#complete-example)
+
+---
+
+## When to Use Hybrid
+
+**Use hybrid plugins when you need:**
+- Rich React UI with custom components
+- Python backend for heavy computation or external APIs
+- Real-time updates from Python to JavaScript
+- Complex state synchronization between frontend and backend
+
+**Use Python-only when:**
+- Simple forms and basic UI
+- Data processing without rich visualization
+- Quick prototyping
+
+**Use JavaScript-only when:**
+- Pure UI enhancements
+- Client-side logic only
+- No backend processing needed
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    FiftyOne App                      │
+├─────────────────────┬───────────────────────────────┤
+│   TypeScript/React  │         Python Backend         │
+│   (Rich UI)         │    (Data Processing)           │
+├─────────────────────┼───────────────────────────────┤
+│ • Custom components │ • foo.Operator classes         │
+│ • Recoil state      │ • foo.Panel classes            │
+│ • Event handlers    │ • ctx.store() persistence      │
+│ • usePanelEvent()   │ • ctx.trigger() communication  │
+└─────────────────────┴───────────────────────────────┘
+```
+
+---
+
+## Plugin Structure
+
+```
+my-hybrid-plugin/
+├── fiftyone.yml           # Plugin manifest
+├── __init__.py            # Python operators and panels
+├── package.json           # Node.js dependencies
+├── tsconfig.json          # TypeScript config
+├── vite.config.ts         # Build config
+├── src/
+│   ├── index.ts           # Plugin entry point
+│   ├── PluginView.tsx     # Main React component
+│   ├── components/        # UI components
+│   ├── hooks/             # Custom React hooks
+│   ├── state/             # Recoil atoms
+│   ├── operators.ts       # TypeScript operators (event handlers)
+│   └── types.ts           # TypeScript interfaces
+├── dist/
+│   └── index.umd.js       # Built bundle (auto-generated)
+└── requirements.txt       # Python dependencies
+```
+
+---
+
+## Python Backend
+
+### Panel with Custom View
+
+```python
+from fiftyone.operators.panel import Panel, PanelConfig
+import fiftyone.operators.types as types
+
+class MyHybridPanel(Panel):
+    @property
+    def config(self):
+        return PanelConfig(
+            name="my_hybrid_panel",
+            label="My Hybrid Panel",
+            icon="dashboard",
+        )
+
+    def on_load(self, ctx):
+        # Initialize data for frontend
+        ctx.panel.set_data("can_edit", True)
+        ctx.panel.set_data("dataset_name", ctx.dataset.name)
+
+    def render(self, ctx):
+        return types.Property(
+            types.Object(),
+            view=types.View(
+                component="PluginView",  # Matches React component name
+                composite_view=True,
+                # Expose Python methods to frontend
+                process_data=self.process_data,
+                get_status=self.get_status,
+            ),
+        )
+
+    def process_data(self, ctx):
+        """Called from frontend via usePanelEvent()"""
+        params = ctx.params
+        result = heavy_computation(params)
+        ctx.panel.set_data("result", result)
+        return {"success": True, "count": len(result)}
+
+    def get_status(self, ctx):
+        """Return current processing status"""
+        store = ctx.store(f"my_plugin_{ctx.dataset._doc.id}")
+        return {"status": store.get("status") or "idle"}
+```
+
+### Backend Operator with Store
+
+```python
+class ProcessingOperator(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="process_data",
+            label="Process Data",
+            allow_delegated_execution=True,
+            execute_as_generator=True,
+        )
+
+    def execute(self, ctx):
+        plugin_name = self.config.name.split("/")[-1]
+        store = ctx.store(f"{plugin_name}_{ctx.dataset._doc.id}")
+
+        total = len(ctx.target_view())
+        for i, sample in enumerate(ctx.target_view()):
+            # Process sample...
+            store.set(f"sample_{sample.id}_status", "completed")
+
+            # Send progress update to frontend
+            yield ctx.trigger(
+                "@myorg/my-plugin/progress_update",
+                {"progress": (i + 1) / total, "sample_id": sample.id}
+            )
+
+        store.set("status", "completed")
+        yield {"success": True, "total": total}
+```
+
+---
+
+## TypeScript Frontend
+
+### Custom View Component
+
+```typescript
+// src/PluginView.tsx
+import React, { useEffect, useRef } from "react";
+import { Box, Typography, Button, LinearProgress } from "@mui/material";
+import { usePluginClient } from "./hooks/usePluginClient";
+import { useRecoilState } from "recoil";
+import { progressAtom } from "./state/progress";
+
+export default function PluginView() {
+  const client = usePluginClient();
+  const [progress, setProgress] = useRecoilState(progressAtom);
+  const hasLoadedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasLoadedRef.current) {
+      hasLoadedRef.current = true;
+      client.get_status().then((result) => {
+        if (result?.result?.status) {
+          setProgress((prev) => ({ ...prev, status: result.result.status }));
+        }
+      });
+    }
+  }, []);
+
+  const handleProcess = async () => {
+    setProgress({ status: "running", value: 0 });
+    const result = await client.process_data({ option: "selected" });
+    if (result?.result?.success) {
+      setProgress({ status: "completed", value: 100 });
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h5">My Hybrid Plugin</Typography>
+
+      {progress.status === "running" && (
+        <LinearProgress variant="determinate" value={progress.value * 100} />
+      )}
+
+      <Button onClick={handleProcess} variant="contained">
+        Process Data
+      </Button>
+    </Box>
+  );
+}
+```
+
+### State Management with Recoil
+
+```typescript
+// src/state/progress.ts
+import { atom } from "recoil";
+
+export interface ProgressState {
+  status: "idle" | "running" | "completed" | "failed";
+  value: number;
+  message?: string;
+}
+
+export const progressAtom = atom<ProgressState>({
+  key: "myPluginProgress",  // Unique key per plugin
+  default: { status: "idle", value: 0 },
+});
+```
+
+### Client Hook for Backend Communication
+
+```typescript
+// src/hooks/usePluginClient.ts
+import { useCallback } from "react";
+import { usePanelEvent } from "@fiftyone/operators";
+
+export interface PluginClient {
+  process_data: (params: { option: string }) => Promise<any>;
+  get_status: () => Promise<any>;
+}
+
+export function usePluginClient(): PluginClient {
+  const handleEvent = usePanelEvent();
+  const pluginNamespace = "@myorg/my-plugin";  // Your plugin namespace
+
+  return {
+    process_data: useCallback(
+      async (params) => {
+        return new Promise((resolve, reject) => {
+          handleEvent("process_data", {
+            operator: `${pluginNamespace}/my_hybrid_panel#process_data`,
+            params,
+            callback: (result: any) => {
+              result?.error ? reject(new Error(result.error)) : resolve(result);
+            },
+          });
+        });
+      },
+      [handleEvent]
+    ),
+
+    get_status: useCallback(
+      async () => {
+        return new Promise((resolve, reject) => {
+          handleEvent("get_status", {
+            operator: `${pluginNamespace}/my_hybrid_panel#get_status`,
+            params: {},
+            callback: (result: any) => {
+              result?.error ? reject(new Error(result.error)) : resolve(result);
+            },
+          });
+        });
+      },
+      [handleEvent]
+    ),
+  };
+}
+```
+
+---
+
+## Communication Patterns
+
+### Frontend → Backend
+
+```typescript
+// Call Python panel method
+const result = await client.process_data({ option: "value" });
+
+// Call Python operator
+import { useOperatorExecutor } from "@fiftyone/operators";
+const executor = useOperatorExecutor("@myorg/my-plugin/process_data");
+await executor.execute({ param1: "value" });
+```
+
+### Backend → Frontend
+
+```python
+# Trigger TypeScript operator to update frontend state
+ctx.trigger(
+    "@myorg/my-plugin/progress_update",
+    {"progress": 0.5, "message": "Processing..."}
+)
+```
+
+### Real-time State Sync
+
+```typescript
+// TypeScript operator receives Python trigger and updates Recoil state
+class ProgressUpdateOperator extends Operator {
+  get config() {
+    return new OperatorConfig({
+      name: "progress_update",
+      label: "Progress Update",
+      unlisted: true,  // Hide from operator browser
+    });
+  }
+
+  useHooks() {
+    const setProgress = useSetRecoilState(progressAtom);
+    return { setProgress };
+  }
+
+  async execute({ hooks, params }) {
+    hooks.setProgress({
+      status: "running",
+      value: params.progress,
+      message: params.message,
+    });
+  }
+}
+```
+
+---
+
+## TypeScript Operators
+
+TypeScript operators act as **event handlers** for Python triggers:
+
+```typescript
+// src/operators.ts
+import {
+  Operator,
+  OperatorConfig,
+  registerOperator,
+} from "@fiftyone/operators";
+import { useSetRecoilState } from "recoil";
+import { progressAtom } from "./state/progress";
+
+class ProgressUpdateOperator extends Operator {
+  get config() {
+    return new OperatorConfig({
+      name: "progress_update",
+      label: "Progress Update",
+      unlisted: true,  // Event handler, not user-facing
+    });
+  }
+
+  useHooks() {
+    const setProgress = useSetRecoilState(progressAtom);
+    return { setProgress };
+  }
+
+  async execute({ hooks, params }) {
+    const { progress, message, status } = params;
+    hooks.setProgress((prev) => ({
+      ...prev,
+      value: progress ?? prev.value,
+      message: message ?? prev.message,
+      status: status ?? prev.status,
+    }));
+  }
+}
+
+// Register in src/index.ts
+registerOperator(ProgressUpdateOperator, "@myorg/my-plugin");
+```
+
+---
+
+## Build Configuration
+
+### package.json
+
+```json
+{
+  "name": "@myorg/my-hybrid-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "fiftyone": {
+    "script": "dist/index.umd.js"
+  },
+  "scripts": {
+    "dev": "vite build --watch",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@fiftyone/components": "*",
+    "@fiftyone/operators": "*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recoil": "^0.7.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "@voxel51/fiftyone-js-plugin-build": "^2.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}
+```
+
+### vite.config.ts
+
+```typescript
+import { defineConfig } from "@voxel51/fiftyone-js-plugin-build";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig(__dirname, {
+  buildConfigOverride: { sourcemap: true },
+});
+```
+
+### tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
+---
+
+## Complete Example
+
+### fiftyone.yml
+
+```yaml
+name: "@myorg/sample-processor"
+version: "1.0.0"
+description: "Process samples with real-time progress"
+fiftyone:
+  version: "*"
+operators:
+  - process_samples
+panels:
+  - processor_panel
+```
+
+### __init__.py
+
+```python
+import fiftyone.operators as foo
+import fiftyone.operators.types as types
+from fiftyone.operators.panel import Panel, PanelConfig
+
+class ProcessorPanel(Panel):
+    @property
+    def config(self):
+        return PanelConfig(
+            name="processor_panel",
+            label="Sample Processor",
+            icon="play_arrow",
+        )
+
+    def on_load(self, ctx):
+        store = ctx.store(f"processor_{ctx.dataset._doc.id}")
+        ctx.panel.set_data("status", store.get("status") or "idle")
+
+    def render(self, ctx):
+        return types.Property(
+            types.Object(),
+            view=types.View(
+                component="ProcessorView",
+                composite_view=True,
+                start_processing=self.start_processing,
+            ),
+        )
+
+    def start_processing(self, ctx):
+        # Trigger the background operator
+        ctx.trigger("@myorg/sample-processor/process_samples", ctx.params)
+        return {"started": True}
+
+
+class ProcessSamplesOperator(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="process_samples",
+            label="Process Samples",
+            allow_delegated_execution=True,
+            execute_as_generator=True,
+        )
+
+    def execute(self, ctx):
+        view = ctx.target_view()
+        total = len(view)
+
+        for i, sample in enumerate(view):
+            # Process sample...
+
+            # Send progress to frontend
+            yield ctx.trigger(
+                "@myorg/sample-processor/update_progress",
+                {"progress": (i + 1) / total}
+            )
+
+        yield {"success": True, "processed": total}
+
+
+def register(p):
+    p.register(ProcessorPanel)
+    p.register(ProcessSamplesOperator)
+```
+
+### src/index.ts
+
+```typescript
+import { registerComponent, PluginComponentType } from "@fiftyone/plugins";
+import { registerOperator } from "@fiftyone/operators";
+import ProcessorView from "./ProcessorView";
+import { UpdateProgressOperator } from "./operators";
+
+// Register React component
+registerComponent({
+  name: "ProcessorView",
+  component: ProcessorView,
+  type: PluginComponentType.Panel,
+});
+
+// Register event handler operator
+registerOperator(UpdateProgressOperator, "@myorg/sample-processor");
+```
+
+### Development Workflow
+
+```bash
+# Terminal 1: Watch TypeScript changes
+cd my-hybrid-plugin && npm run dev
+
+# Terminal 2: Launch FiftyOne App
+python -c "import fiftyone as fo; fo.launch_app()"
+```
+
+Changes to TypeScript files auto-rebuild. Refresh the FiftyOne App to see updates.

--- a/skills/fiftyone-develop-plugin/SKILL.md
+++ b/skills/fiftyone-develop-plugin/SKILL.md
@@ -28,6 +28,97 @@ Install plugin and verify it works in FiftyOne App.
 ### 5. Iterate on feedback
 Refine until the plugin works as expected.
 
+## Critical Patterns
+
+### Operator Execution
+```python
+# Use foo.execute_operator() for programmatic execution
+import fiftyone.operators as foo
+result = foo.execute_operator(operator_uri, ctx, **params)
+
+# Use ctx.trigger() to chain operators from within an operator
+ctx.trigger("@plugin/other_operator", params={...})
+
+# ctx.ops provides UI operations: notify(), set_progress(), show_panel_output()
+```
+
+### View Selection
+```python
+# Use ctx.target_view() to respect user's current selection and filters
+view = ctx.target_view()
+
+# ctx.dataset - Full dataset (use when explicitly exporting all)
+# ctx.view - Filtered view (use for read-only operations)
+# ctx.target_view() - Filtered + selected samples (use for exports/processing)
+```
+
+### Store Keys (Avoid Collisions)
+```python
+# Use namespaced keys to avoid cross-dataset conflicts
+def _get_store_key(self, ctx):
+    plugin_name = self.config.name.split("/")[-1]
+    return f"{plugin_name}_store_{ctx.dataset._doc.id}_{self.version}"
+
+store = ctx.store(self._get_store_key(ctx))
+```
+
+### Panel State vs Execution Store
+```python
+# ctx.panel.state - Transient (resets when panel reloads)
+# ctx.store() - Persistent (survives across sessions)
+
+def on_load(self, ctx):
+    ctx.panel.state.selected_tab = "overview"  # Transient
+    store = ctx.store(self._get_store_key(ctx))
+    ctx.panel.state.config = store.get("user_config") or {}  # Persistent
+```
+
+### Delegated Execution
+Use for operations that: process >100 samples, take >1 second, or call external APIs.
+
+```python
+@property
+def config(self):
+    return foo.OperatorConfig(
+        name="heavy_operator",
+        allow_delegated_execution=True,
+        default_choice_to_delegated=True,
+    )
+```
+
+### Progress Reporting
+```python
+@property
+def config(self):
+    return foo.OperatorConfig(
+        name="progress_operator",
+        execute_as_generator=True,
+    )
+
+def execute(self, ctx):
+    total = len(ctx.target_view())
+    for i, sample in enumerate(ctx.target_view()):
+        # Process sample...
+        yield ctx.trigger("set_progress", {"progress": (i+1)/total})
+    yield {"status": "complete"}
+```
+
+### Custom Runs (Auditability)
+Use Custom Runs for operations needing reproducibility and history tracking:
+
+```python
+# Create run key (must be valid Python identifier - use underscores, not slashes)
+run_key = f"my_plugin_{self.config.name}_v1_{timestamp}"
+
+# Initialize and register
+run_config = ctx.dataset.init_run(operator=self.config.name, params=ctx.params)
+ctx.dataset.register_run(run_key, run_config)
+```
+
+See [PYTHON-OPERATOR.md](PYTHON-OPERATOR.md#custom-runs-auditable-operations) for full Custom Runs pattern.
+See [EXECUTION-STORE.md](EXECUTION-STORE.md) for advanced caching patterns.
+See [HYBRID-PLUGINS.md](HYBRID-PLUGINS.md) for Python + JavaScript communication.
+
 ## Workflow
 
 ### Phase 1: Requirements
@@ -66,29 +157,49 @@ Create these files:
 | `src/index.tsx` | JS only | React components |
 
 Reference docs:
-- [PYTHON-OPERATOR.md](PYTHON-OPERATOR.md)
-- [PYTHON-PANEL.md](PYTHON-PANEL.md)
-- [JAVASCRIPT-PANEL.md](JAVASCRIPT-PANEL.md)
+- [PYTHON-OPERATOR.md](PYTHON-OPERATOR.md) - Python operators
+- [PYTHON-PANEL.md](PYTHON-PANEL.md) - Python panels
+- [JAVASCRIPT-PANEL.md](JAVASCRIPT-PANEL.md) - React/TypeScript panels
+- [HYBRID-PLUGINS.md](HYBRID-PLUGINS.md) - Python + JavaScript communication
+- [EXECUTION-STORE.md](EXECUTION-STORE.md) - Persistent storage and caching
 
 ### Phase 4: Install & Test
 
+#### 4.1 Install Plugin
 ```bash
 # Find plugins directory
 python -c "import fiftyone as fo; print(fo.config.plugins_dir)"
 
 # Copy plugin
 cp -r ./my-plugin ~/.fiftyone/plugins/
-
-# Verify detection
-python -c "import fiftyone as fo; print(fo.plugins.list_plugins())"
 ```
 
-Test in App:
+#### 4.2 Validate Detection
 ```python
-launch_app(dataset_name="test-dataset")
-# Press Cmd/Ctrl + ` to open operator browser
-# Search for your operator
+list_plugins(enabled=True)  # Should show your plugin
+list_operators()  # Should show your operators
 ```
+
+**If not found:** Check fiftyone.yml syntax, Python syntax errors, restart App.
+
+#### 4.3 Validate Schema
+```python
+get_operator_schema(operator_uri="@myorg/my-operator")
+```
+
+Verify inputs/outputs match your expectations.
+
+#### 4.4 Test Execution
+```python
+set_context(dataset_name="test-dataset")
+launch_app()
+execute_operator(operator_uri="@myorg/my-operator", params={...})
+```
+
+**Common failures:**
+- "Operator not found" → Check fiftyone.yml operators list
+- "Missing parameter" → Check resolve_input() required fields
+- "Execution error" → Check execute() implementation
 
 ### Phase 5: Iterate
 
@@ -110,12 +221,25 @@ launch_app(dataset_name="test-dataset")
 
 ### Operator Config Options
 
-| Option | Effect |
-|--------|--------|
-| `dynamic=True` | Recalculate inputs on change |
-| `execute_as_generator=True` | Stream progress |
-| `allow_delegated_execution=True` | Background execution |
-| `unlisted=True` | Hide from browser |
+| Option | Default | Effect |
+|--------|---------|--------|
+| `dynamic` | False | Recalculate inputs on change |
+| `execute_as_generator` | False | Stream progress with yield |
+| `allow_immediate_execution` | True | Execute in foreground |
+| `allow_delegated_execution` | False | Background execution |
+| `default_choice_to_delegated` | False | Default to background |
+| `unlisted` | False | Hide from operator browser |
+| `on_startup` | False | Execute when app starts |
+| `on_dataset_open` | False | Execute when dataset opens |
+
+### Panel Config Options
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `allow_multiple` | False | Allow multiple panel instances |
+| `surfaces` | "grid" | Where panel can display ("grid", "modal", "grid modal") |
+| `category` | None | Panel category in browser |
+| `priority` | None | Sort order in UI |
 
 ### Input Types
 
@@ -163,6 +287,63 @@ class HelloWorld(foo.Operator):
 def register(p):
     p.register(HelloWorld)
 ```
+
+## Debugging
+
+### Where Logs Go
+
+| Log Type | Location |
+|----------|----------|
+| Python backend | Terminal running the server |
+| JavaScript frontend | Browser console (F12 → Console) |
+| Network requests | Browser DevTools (F12 → Network) |
+| Operator errors | Operator browser in FiftyOne App |
+
+### Running Server Separately (Recommended for Development)
+
+To see Python plugin logs, run the server and app separately:
+
+```bash
+# Terminal 1: Run FiftyOne server (shows Python logs)
+python -m fiftyone.server.main
+
+# Terminal 2: Access the app in browser
+# Logs from print() and logging will appear in Terminal 1
+```
+
+### Python Debugging
+
+```python
+def execute(self, ctx):
+    # Use print() for quick debugging (shows in server terminal)
+    print(f"Params received: {ctx.params}")
+    print(f"Dataset: {ctx.dataset.name}, View size: {len(ctx.view)}")
+
+    # For structured logging
+    import logging
+    logging.info(f"Processing {len(ctx.target_view())} samples")
+
+    # ... rest of execution
+```
+
+### JavaScript/TypeScript Debugging
+
+```typescript
+// Use console.log in React components
+console.log("Component state:", state);
+console.log("Panel data:", panelData);
+
+// Check browser DevTools:
+// - Console: JS errors, syntax errors, plugin load failures
+// - Network: API calls, variable values before/after execution
+```
+
+### Common Debug Locations
+
+- **Operator not executing**: Check Network tab for request/response
+- **Plugin not loading**: Check Console for syntax errors
+- **Variables not updating**: Check Network tab for payload data
+- **Silent failures**: Check Operator browser for error messages
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Summary

Improved the **`fiftyone-develop-plugin` skill** using verified API patterns from the FiftyOne knowledge base, internal suggestion and the main source code.

### What’s changed

* Added validated examples and debugging guides
* Documented **Custom Runs** usage
* Fixed incorrect patterns:
  * `run_key` format
  * progress reporting
* All code examples are now **tested against FiftyOne v1.11.1**

### Documentation restructure

* **`SKILL.md`**
Main entry point with quick patterns and workflow steps. Guides the agent on *what to do* and links to deeper references.

* **Reference files**
  Detailed, topic-specific examples (Used when deeper implementation details are needed):
  * `PYTHON-OPERATOR.md`
  * `PYTHON-PANEL.md`
  * `JAVASCRIPT-PANEL.md`
  * `HYBRID-PLUGINS.md`
  * `EXECUTION-STORE.md`

* **`PLUGIN-STRUCTURE.md`**
  Quick reference for plugin file structure, formats, and configuration templates.