### PR TITLE
Add Claude Code plugin registry support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "fiftyone",
+  "description": "Build high-quality datasets and computer vision models. Visualize datasets, analyze models, find duplicates, run inference, evaluate predictions, and develop custom plugins.",
+  "version": "1.0.3",
+  "author": {
+    "name": "Voxel51"
+  },
+  "homepage": "https://docs.voxel51.com/",
+  "repository": "https://github.com/voxel51/fiftyone-skills",
+  "license": "Apache-2.0"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "fiftyone": {
+      "command": "fiftyone-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}

--- a/commands/help.md
+++ b/commands/help.md
@@ -1,0 +1,93 @@
+---
+description: Get help with FiftyOne skills, understand available workflows, and troubleshoot setup issues
+---
+
+# FiftyOne Skills Help
+
+This plugin provides expert workflows for building high-quality datasets and computer vision models using [FiftyOne](https://docs.voxel51.com/).
+
+## When to Use This Help
+
+- First time using FiftyOne skills
+- Encountering setup or configuration issues
+- Want to understand what skills are available
+
+## Prerequisites
+
+Before using FiftyOne skills, ensure the MCP server is installed:
+
+```bash
+pip install fiftyone-mcp-server
+```
+
+The plugin automatically configures the MCP server connection via `.mcp.json`. If you installed FiftyOne in a virtual environment or conda environment, update the command path in `.mcp.json` to point to your environment's executable:
+
+```json
+{
+  "mcpServers": {
+    "fiftyone": {
+      "command": "/path/to/your/venv/bin/fiftyone-mcp"
+    }
+  }
+}
+```
+
+## Available Skills
+
+### FiftyOne Use
+
+Skills for working with datasets and models:
+
+| Skill | Command | Use When |
+|-------|---------|----------|
+| **Dataset Import** | `/fiftyone:fiftyone-dataset-import` | Importing any dataset (COCO, YOLO, VOC, videos, point clouds, multimodal) |
+| **Dataset Export** | `/fiftyone:fiftyone-dataset-export` | Exporting datasets to standard formats for training or sharing |
+| **Find Duplicates** | `/fiftyone:fiftyone-find-duplicates` | Removing duplicate or near-duplicate images from datasets |
+| **Dataset Inference** | `/fiftyone:fiftyone-dataset-inference` | Running detection, classification, segmentation, or embeddings on data |
+| **Model Evaluation** | `/fiftyone:fiftyone-model-evaluation` | Computing mAP, precision, recall, confusion matrices |
+| **Embeddings Visualization** | `/fiftyone:fiftyone-embeddings-visualization` | Exploring dataset structure, finding clusters, identifying outliers |
+
+### FiftyOne Develop
+
+Skills for developers building with FiftyOne:
+
+| Skill | Command | Use When |
+|-------|---------|----------|
+| **Develop Plugin** | `/fiftyone:fiftyone-develop-plugin` | Creating custom operators or panels for FiftyOne App |
+| **Code Style** | `/fiftyone:fiftyone-code-style` | Writing Python code following FiftyOne conventions |
+| **Issue Triage** | `/fiftyone:fiftyone-issue-triage` | Triaging GitHub issues in the FiftyOne repository |
+
+## Troubleshooting Checklist
+
+If skills aren't working as expected:
+
+1. **Verify MCP server installation**
+   ```bash
+   pip show fiftyone-mcp-server
+   ```
+
+2. **Test MCP connection**
+   Ask: "List my FiftyOne datasets"
+
+   If this works, MCP is properly configured.
+
+3. **Check FiftyOne installation**
+   ```bash
+   pip show fiftyone
+   ```
+
+4. **Verify Python environment**
+   Ensure you're using the same environment where FiftyOne is installed.
+
+## Quick Commands
+
+- `/fiftyone:quickstart` - Guided workflow to get started
+- `/fiftyone:help` - This help document
+
+## Resources
+
+- [FiftyOne Documentation](https://docs.voxel51.com/)
+- [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server)
+- [FiftyOne Plugins](https://github.com/voxel51/fiftyone-plugins)
+- [Discord Community](https://discord.gg/fiftyone-community)
+- [GitHub Issues](https://github.com/voxel51/fiftyone-skills/issues)

--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -1,0 +1,113 @@
+---
+description: Guided quickstart for FiftyOne - choose between user workflows (import, inference, visualization) or developer workflows (plugin development)
+---
+
+# FiftyOne Quickstart
+
+Welcome to FiftyOne! This quickstart will guide you through your first workflow.
+
+## Prerequisites Check
+
+First, let me verify your setup by listing available datasets:
+
+Use the `list_datasets` MCP tool to check the connection.
+
+If this fails, run:
+```bash
+pip install fiftyone-mcp-server
+```
+
+Then check `/fiftyone:help` for environment configuration.
+
+---
+
+## Choose Your Path
+
+### Option 1: User Quickstart
+
+Build and explore a computer vision dataset.
+
+**Step 1: Load a Dataset**
+
+You can either:
+
+- **Use the quickstart dataset** (built-in):
+  ```
+  Load the FiftyOne quickstart dataset
+  ```
+
+- **Import your own dataset**:
+  ```
+  Use /fiftyone:fiftyone-dataset-import to import my dataset from /path/to/data
+  ```
+
+**Step 2: Run Model Inference**
+
+Apply a model to your dataset:
+
+```
+Use /fiftyone:fiftyone-dataset-inference to run object detection on my dataset
+```
+
+This will run a Zoo model (like YOLO or Faster R-CNN) and add predictions to your samples.
+
+**Step 3: Explore in the App**
+
+Launch the FiftyOne App to visualize your data and predictions:
+
+```
+Launch the FiftyOne App with my dataset
+```
+
+From here you can:
+- Browse samples and labels
+- Filter by predictions or ground truth
+- Identify model errors
+
+**Next Steps**
+
+Once you're comfortable, try:
+- `/fiftyone:fiftyone-find-duplicates` - Clean your dataset
+- `/fiftyone:fiftyone-model-evaluation` - Evaluate prediction quality
+- `/fiftyone:fiftyone-embeddings-visualization` - Explore data distribution
+
+---
+
+### Option 2: Developer Quickstart
+
+Create a custom FiftyOne plugin.
+
+**Step 1: Start Plugin Development**
+
+```
+Use /fiftyone:fiftyone-develop-plugin to create a new plugin
+```
+
+The skill will guide you through:
+1. Defining your plugin's purpose
+2. Choosing between operators (actions) or panels (UI)
+3. Generating the plugin structure
+4. Installing and testing locally
+
+**Step 2: Follow the Guided Workflow**
+
+The develop-plugin skill provides comprehensive guidance on:
+- Plugin directory structure
+- Python operator patterns
+- JavaScript/React panels
+- Hybrid plugins with Python backend + JS frontend
+- Testing and debugging
+
+**Next Steps**
+
+For code contributions:
+- `/fiftyone:fiftyone-code-style` - Follow FiftyOne conventions
+- [FiftyOne Plugins Repository](https://github.com/voxel51/fiftyone-plugins) - Browse examples
+
+---
+
+## Need Help?
+
+- `/fiftyone:help` - Full documentation of all skills
+- [FiftyOne Docs](https://docs.voxel51.com/)
+- [Discord Community](https://discord.gg/fiftyone-community)


### PR DESCRIPTION
Add Claude Code plugin registry support with plugin.json, commands, and MCP configuration. Includes /fiftyone:help and /fiftyone:quickstart commands for guided onboarding.
