### PR TITLE
Add VOODO design system skill for UIs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,6 +57,12 @@
       "description": "Write Python code following FiftyOne's official conventions. Use when contributing to FiftyOne, developing plugins, or writing code that integrates with FiftyOne's codebase. Covers module structure, import organization, Google-style docstrings, lazy imports, guard patterns, and error handling."
     },
     {
+      "name": "fiftyone-voodo-design",
+      "source": "./skills/fiftyone-voodo-design",
+      "skills": "./",
+      "description": "Build FiftyOne UIs using VOODO (Voxel Official Design Ontology), the official React component library. Use when building plugin panels, creating interactive UIs, styling FiftyOne applications, or needing React components with proper design tokens. Fetches current component documentation dynamically from llms.txt."
+    },
+    {
       "name": "fiftyone-issue-triage",
       "source": "./skills/fiftyone-issue-triage",
       "skills": "./",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,26 @@ This repository contains skills for computer vision workflows using FiftyOne and
 - Guard patterns with `hasattr()`
 - Error handling with `logger.warning()`
 
+### FiftyOne VOODO Design (`voodo-design/`)
+
+**When to use:** User wants to build FiftyOne UIs with React components, style JavaScript panels, use design tokens, or create consistent FiftyOne App interfaces.
+
+**Instructions:** Load the skill file at `voodo-design/skills/fiftyone-voodo-design/SKILL.md`
+
+**Key requirements:**
+- Node.js 16+ for JavaScript panels
+- `@voxel51/voodo` npm package
+
+**Workflow summary:**
+1. Fetch current VOODO docs via WebFetch from llms.txt
+2. Identify needed components from docs
+3. Use design tokens for colors, spacing, typography
+4. Build panel following FiftyOne patterns (dark theme, responsive)
+
+**Documentation sources:**
+- WebFetch: `https://voodo.dev.fiftyone.ai/llms.txt`
+- Interactive Storybook: `https://voodo.dev.fiftyone.ai/`
+
 ### FiftyOne PR Triage (`pr-triage/`)
 
 **When to use:** User wants to triage GitHub issues, validate if bugs are fixed, categorize issue status, or generate standardized response messages.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Skills bridge the gap between natural language and FiftyOne's 80+ operators, pro
 | 📈 [**Model Evaluation**](skills/fiftyone-model-evaluation/SKILL.md) | Compute mAP, precision, recall, confusion matrices, analyze TP/FP/FN |
 | 📊 [**Embeddings Visualization**](skills/fiftyone-embeddings-visualization/SKILL.md) | Visualize datasets in 2D, find clusters, identify outliers |
 | 🔌 [**Develop Plugin**](skills/fiftyone-develop-plugin/SKILL.md) | Create custom FiftyOne plugins (operators and panels) |
-| 🎨 [**Code Style**](skills/fiftyone-code-style/SKILL.md) | Write Python code following FiftyOne's official conventions |
+| 🎨 [**VOODO Design**](skills/fiftyone-voodo-design/SKILL.md) | Build UIs with VOODO React components and design tokens |
+| 📝 [**Code Style**](skills/fiftyone-code-style/SKILL.md) | Write Python code following FiftyOne's official conventions |
 | 🏷️ [**Issue Triage**](skills/fiftyone-issue-triage/SKILL.md) | Triage GitHub issues: validate status, categorize, generate responses |
 
 ## Quick Start

--- a/commands/help.md
+++ b/commands/help.md
@@ -54,6 +54,7 @@ Skills for developers building with FiftyOne:
 | Skill | Command | Use When |
 |-------|---------|----------|
 | **Develop Plugin** | `/fiftyone:fiftyone-develop-plugin` | Creating custom operators or panels for FiftyOne App |
+| **VOODO Design** | `/fiftyone:fiftyone-voodo-design` | Building UIs with VOODO components, styling FiftyOne panels |
 | **Code Style** | `/fiftyone:fiftyone-code-style` | Writing Python code following FiftyOne conventions |
 | **Issue Triage** | `/fiftyone:fiftyone-issue-triage` | Triaging GitHub issues in the FiftyOne repository |
 

--- a/skills/fiftyone-develop-plugin/JAVASCRIPT-PANEL.md
+++ b/skills/fiftyone-develop-plugin/JAVASCRIPT-PANEL.md
@@ -73,7 +73,8 @@ panels:
     "@fiftyone/components": "*",
     "@fiftyone/operators": "*",
     "@fiftyone/plugins": "*",
-    "@fiftyone/state": "*"
+    "@fiftyone/state": "*",
+    "@voxel51/voodo": "latest"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -274,6 +275,35 @@ const OperatorTrigger: React.FC = () => {
 ```
 
 ## Styling
+
+### Using VOODO Components (Recommended)
+
+**VOODO** is FiftyOne's official React component library. Use it for consistent, theme-aware UI components.
+
+```bash
+npm install @voxel51/voodo
+```
+
+```typescript
+import { Button, Input, Select, Toast, Stack, Heading, Text } from "@voxel51/voodo";
+
+const MyPanel: React.FC = () => {
+  return (
+    <Stack spacing="md">
+      <Heading level={2}>Panel Title</Heading>
+      <Input placeholder="Enter value..." />
+      <Button variant="primary">Submit</Button>
+    </Stack>
+  );
+};
+```
+
+**For complete VOODO documentation**: Invoke the `fiftyone-voodo-design` skill, which:
+- Fetches current components from llms.txt
+- Lists design tokens (colors, spacing, typography)
+- Provides usage patterns and Storybook links
+
+**Quick reference**: https://voodo.dev.fiftyone.ai/
 
 ### Using Tailwind CSS
 

--- a/skills/fiftyone-develop-plugin/SKILL.md
+++ b/skills/fiftyone-develop-plugin/SKILL.md
@@ -163,6 +163,8 @@ Reference docs:
 - [HYBRID-PLUGINS.md](HYBRID-PLUGINS.md) - Python + JavaScript communication
 - [EXECUTION-STORE.md](EXECUTION-STORE.md) - Persistent storage and caching
 
+**For JavaScript panels with rich UI**: Invoke the `fiftyone-voodo-design` skill for VOODO components (buttons, inputs, toasts, design tokens). VOODO is FiftyOne's official React component library.
+
 ### Phase 4: Install & Test
 
 #### 4.1 Install Plugin
@@ -217,7 +219,7 @@ execute_operator(operator_uri="@myorg/my-operator", params={...})
 |------|----------|----------|
 | Operator | Python | Data processing, computations |
 | Panel | Python | Simple interactive UI |
-| Panel | JavaScript | Rich React-based UI |
+| Panel | JavaScript | Rich React-based UI (use VOODO components) |
 
 ### Operator Config Options
 

--- a/skills/fiftyone-voodo-design/SKILL.md
+++ b/skills/fiftyone-voodo-design/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: fiftyone-voodo-design
+description: Build FiftyOne UIs using VOODO (Voxel Official Design Ontology), the official React component library. Use when building plugin panels, creating interactive UIs, or styling FiftyOne applications. Fetches current documentation dynamically from llms.txt.
+---
+
+# VOODO Design System for FiftyOne
+
+VOODO is the official React component library for FiftyOne applications.
+
+**Documentation is fetched dynamically** - always get current components from llms.txt before writing code.
+
+## Key Directive
+
+**ALWAYS fetch llms.txt BEFORE writing any UI code:**
+
+```
+WebFetch(
+    url="https://voodo.dev.fiftyone.ai/llms.txt",
+    prompt="List all available VOODO components with their variants and use cases"
+)
+```
+
+This gives you:
+- All current components (buttons, inputs, toasts, etc.)
+- Available variants for each component
+- Design token categories (colors, spacing, typography)
+- Links to interactive Storybook docs
+
+## Workflow
+
+### 1. Fetch component list
+
+```
+WebFetch(
+    url="https://voodo.dev.fiftyone.ai/llms.txt",
+    prompt="What VOODO components are available for building forms?"
+)
+```
+
+### 2. Use components from the fetched list
+
+```typescript
+// Import only components that exist in llms.txt
+import { Button, Input, Select } from "@voxel51/voodo";
+```
+
+### 3. For detailed props, direct user to Storybook
+
+The llms.txt includes Storybook links for each component. For detailed prop documentation:
+
+```
+"For Button props and examples, see: https://voodo.dev.fiftyone.ai/?path=/docs/components-button--docs"
+```
+
+**Note**: Storybook is a JavaScript app - WebFetch cannot extract its content. Direct users to browse interactively.
+
+## Installation
+
+```json
+{
+  "dependencies": {
+    "@voxel51/voodo": "latest"
+  }
+}
+```
+
+## FiftyOne Patterns
+
+- **Dark theme**: FiftyOne App uses dark mode by default
+- **Semantic variants**: Use success/danger/warning for actions (verify names from llms.txt)
+- **Design tokens**: Use spacing/color tokens instead of arbitrary values
+
+## Integration with FiftyOne SDK
+
+```typescript
+import { useRecoilValue } from "recoil";
+import * as fos from "@fiftyone/state";  // Standard FiftyOne alias
+import { Button, Text, Stack } from "@voxel51/voodo";
+
+const MyPanel: React.FC = () => {
+  const dataset = useRecoilValue(fos.dataset);
+  return (
+    <Stack>
+      <Text>{dataset?.name}</Text>
+      <Button>Process</Button>
+    </Stack>
+  );
+};
+```
+
+## Resources
+
+| Resource | URL |
+|----------|-----|
+| **llms.txt** (fetch first) | https://voodo.dev.fiftyone.ai/llms.txt |
+| **Interactive Storybook** | https://voodo.dev.fiftyone.ai/ |
+| **npm package** | `@voxel51/voodo` |
+
+**Related**: Use `fiftyone-develop-plugin` skill for full plugin setup.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Component not found | Fetch llms.txt to verify current name |
+| Props not working | Direct user to Storybook for current API |
+| Styles not applying | Test in dark mode, use design tokens |


### PR DESCRIPTION
**Summary**

* Adds the `fiftyone-voodo-design` skill, which dynamically fetches VOODO component documentation from `llms.txt` to support building FiftyOne plugin UIs.
* Integrates the skill with `fiftyone-develop-plugin` via cross-references in `SKILL.md` and `JAVASCRIPT-PANEL.md`.
* Adds `@voxel51/voodo` to the JavaScript panel `package.json` template.
* Updates `marketplace.json`, `README.md`, `AGENTS.md`, and `help.md` to include the new skill.