### PR TITLE
Add notebook creation skill for FiftyOne workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -67,6 +67,12 @@
       "source": "./skills/fiftyone-issue-triage",
       "skills": "./",
       "description": "Triage FiftyOne GitHub issues by validating status, categorizing resolution, and generating standardized responses. Use when reviewing issues to determine if already fixed, won't fix, not reproducible, no longer relevant, or still valid. Includes investigation workflow and response templates."
+    },
+    {
+      "name": "fiftyone-create-notebook",
+      "source": "./skills/fiftyone-create-notebook",
+      "skills": "./",
+      "description": "Creates Jupyter notebooks for FiftyOne workflows including getting-started guides, tutorials, recipes, and full ML pipelines. Use when users want to create a notebook, write a tutorial, build a demo, document a workflow, or generate a FiftyOne walkthrough covering data loading, exploration, inference, evaluation, and export. Builds notebooks cell-by-cell using NotebookEdit."
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,32 @@ This repository contains skills for computer vision workflows using FiftyOne and
 - WebFetch: `https://voodo.dev.fiftyone.ai/llms.txt`
 - Interactive Storybook: `https://voodo.dev.fiftyone.ai/`
 
+### FiftyOne Create Notebook (`fiftyone-create-notebook/`)
+
+**When to use:** User wants to create a Jupyter notebook for a FiftyOne workflow, write a tutorial, build a getting-started guide, create a recipe, generate a demo, or document a complete ML pipeline.
+
+**Instructions:** Load the skill file at `skills/fiftyone-create-notebook/SKILL.md`
+
+**Key requirements:**
+- FiftyOne installed
+- NotebookEdit tool available (built-in to Claude Code)
+- No MCP server required (generates Python SDK code, not MCP operations)
+
+**Workflow summary:**
+1. Determine notebook type (getting-started, tutorial, recipe, full pipeline)
+2. Gather requirements (domain, data source, pipeline stages)
+3. Fetch current FiftyOne API from `https://docs.voxel51.com/llms.txt`
+4. Draft and present notebook outline for user approval
+5. Create empty `.ipynb` file with Write tool
+6. Build cells sequentially with NotebookEdit insert mode
+7. Verify notebook structure by reading it back
+
+**Reference files:**
+- `NOTEBOOK-STRUCTURE.md` - Cell structure patterns and code references
+- `GETTING-STARTED-TEMPLATES.md` - Beginner end-to-end templates
+- `TUTORIAL-TEMPLATES.md` - Intermediate deep-dive templates
+- `RECIPE-TEMPLATES.md` - Quick practical recipe templates
+
 ### FiftyOne Issue Triage (`fiftyone-issue-triage/`)
 
 **When to use:** User wants to triage GitHub issues, validate if bugs are fixed, categorize issue status, or generate standardized response messages.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Skills bridge the gap between natural language and FiftyOne's 80+ operators, pro
 | 🔌 [**Develop Plugin**](skills/fiftyone-develop-plugin/SKILL.md) | Create custom FiftyOne plugins (operators and panels) | — |
 | 🎨 [**VOODO Design**](skills/fiftyone-voodo-design/SKILL.md) | Build UIs with VOODO React components and design tokens | — |
 | 📝 [**Code Style**](skills/fiftyone-code-style/SKILL.md) | Write Python code following FiftyOne's official conventions | — |
+| 📓 [**Create Notebook**](skills/fiftyone-create-notebook/SKILL.md) | Create Jupyter notebooks: getting-started guides, tutorials, recipes, ML pipelines | — |
 | 🏷️ [**Issue Triage**](skills/fiftyone-issue-triage/SKILL.md) | Triage GitHub issues: validate status, categorize, generate responses | — |
 
 ## Quick Start

--- a/commands/help.md
+++ b/commands/help.md
@@ -46,6 +46,7 @@ Skills for working with datasets and models:
 | **Dataset Inference** | `/fiftyone:fiftyone-dataset-inference` | Running detection, classification, segmentation, or embeddings on data |
 | **Model Evaluation** | `/fiftyone:fiftyone-model-evaluation` | Computing mAP, precision, recall, confusion matrices |
 | **Embeddings Visualization** | `/fiftyone:fiftyone-embeddings-visualization` | Exploring dataset structure, finding clusters, identifying outliers |
+| **Create Notebook** | `/fiftyone:fiftyone-create-notebook` | Creating Jupyter notebooks for tutorials, getting-started guides, recipes, or ML pipelines |
 
 ### FiftyOne Develop
 

--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -75,6 +75,7 @@ Once you're comfortable, try:
 - `/fiftyone:fiftyone-find-duplicates` - Clean your dataset
 - `/fiftyone:fiftyone-model-evaluation` - Evaluate prediction quality
 - `/fiftyone:fiftyone-embeddings-visualization` - Explore data distribution
+- `/fiftyone:fiftyone-create-notebook` - Generate a full ML pipeline notebook
 
 ---
 

--- a/skills/fiftyone-create-notebook/GETTING-STARTED-TEMPLATES.md
+++ b/skills/fiftyone-create-notebook/GETTING-STARTED-TEMPLATES.md
@@ -1,0 +1,358 @@
+# Getting Started Templates
+
+## Contents
+- [Canonical Structure](#canonical-structure)
+- [Template: Object Detection](#template-object-detection)
+- [Template: Image Classification](#template-image-classification)
+- [Template: Image Similarity & Embeddings](#template-image-similarity--embeddings)
+- [Adaptation Guidelines](#adaptation-guidelines)
+- [Guide Packaging](#guide-packaging)
+
+---
+
+**Target audience:** Beginners new to FiftyOne
+**Duration:** 15-30 minutes
+**Cell count:** 15-22 cells
+**Scope:** Full end-to-end pipeline for one domain
+
+The templates below are **structural examples** — follow the canonical structure and cell patterns, but adapt the dataset, model, field names, and sections to the user's specific domain. Fetch `https://docs.voxel51.com/llms.txt` for the correct API for any domain.
+
+## Canonical Structure
+
+| Phase | Typical Cells | Content |
+|---|---|---|
+| Title | 0 | `# Getting Started with {Domain} in FiftyOne` + metadata + overview |
+| Learning Goals | 1 | `## What You Will Learn` + bullet list of skills |
+| Setup | 2-4 | pip install + setup markdown + imports |
+| Load Data | 5-6 | Explain dataset + load from zoo + inspect |
+| Explore | 7-10 | Launch App + what to look for + dataset statistics |
+| Core Workflow | varies | Domain-specific: inference, brain methods, or analysis |
+| Evaluate | varies | Evaluation + report + error analysis (if applicable) |
+| Export | varies | Explain format + export (optional) |
+| Conclusion | last 2 | Summary + next steps links + cleanup |
+
+## Template: Object Detection
+
+### Cell 0 — markdown
+```markdown
+# Getting Started with Object Detection in FiftyOne
+
+**Level:** Beginner | **Time:** 20 minutes | **Prerequisites:** Basic Python
+
+In this notebook, you will load an object detection dataset, explore it visually,
+run a state-of-the-art detection model, evaluate its predictions against ground
+truth annotations, and export the results. By the end, you will have a complete
+understanding of the FiftyOne detection workflow.
+```
+
+### Cell 1 — markdown
+```markdown
+## What You Will Learn
+
+- Load a detection dataset from the FiftyOne Dataset Zoo
+- Explore images and annotations in the FiftyOne App
+- Run YOLOv8 object detection on your dataset
+- Evaluate predictions using COCO-style metrics (mAP, precision, recall)
+- Analyze false positives and false negatives with evaluation patches
+- Export your dataset to YOLO format for training
+```
+
+### Cell 2 — code
+```python
+!pip install -q fiftyone ultralytics
+```
+
+### Cell 3 — markdown
+```markdown
+## Setup
+
+Import the libraries we will use throughout this notebook.
+```
+
+### Cell 4 — code
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+from fiftyone import ViewField as F
+```
+
+### Cell 5 — markdown
+```markdown
+## Load the Dataset
+
+We will use a subset of the [COCO 2017](https://cocodataset.org/) validation set.
+COCO is one of the most widely used benchmarks for object detection, containing
+80 object categories with bounding box annotations.
+
+We load 200 samples to keep things fast while still being representative.
+```
+
+### Cell 6 — code
+```python
+dataset = foz.load_zoo_dataset(
+    "coco-2017",
+    split="validation",
+    max_samples=200,
+    seed=51,
+    dataset_name="detection-getting-started",
+)
+
+print(dataset)
+
+# Inspect a single sample to understand the data structure
+print(dataset.first())
+```
+
+### Cell 7 — markdown
+```markdown
+## Explore in the FiftyOne App
+
+Launch the FiftyOne App to visually browse images and their annotations.
+Click on any image to see its bounding boxes and labels.
+```
+
+### Cell 8 — code
+```python
+session = fo.launch_app(dataset)
+```
+
+### Cell 9 — markdown
+```markdown
+## Understand the Data
+
+Let's look at the class distribution to understand what objects appear
+most frequently in our dataset.
+```
+
+### Cell 10 — code
+```python
+# Count detections per class
+counts = dataset.count_values("ground_truth.detections.label")
+top_classes = dict(sorted(counts.items(), key=lambda x: -x[1])[:15])
+print("Top 15 classes by detection count:")
+for cls, count in top_classes.items():
+    print(f"  {cls}: {count}")
+```
+
+### Cell 11 — markdown
+```markdown
+## Run Object Detection
+
+Now let's run a YOLOv8 model to generate predictions and compare them
+against the ground truth annotations. YOLOv8-small balances speed and
+accuracy well for this demonstration.
+```
+
+### Cell 12 — code
+```python
+model = foz.load_zoo_model("yolov8s-coco-torch")
+
+dataset.apply_model(model, label_field="predictions")
+
+print(dataset)
+
+# Refresh the App to see predictions alongside ground truth
+session.view = dataset.view()
+```
+
+### Cell 13 — markdown
+```markdown
+## Evaluate Predictions
+
+Compare the model's predictions against the ground truth using
+COCO-style evaluation. This computes mAP (mean Average Precision),
+per-class precision and recall, and marks each prediction as a
+true positive (TP), false positive (FP), or false negative (FN).
+```
+
+### Cell 14 — code
+```python
+results = dataset.evaluate_detections(
+    "predictions",
+    gt_field="ground_truth",
+    eval_key="eval",
+    method="coco",
+    compute_mAP=True,
+)
+
+results.print_report(classes=["person", "car", "dog", "cat", "chair"])
+print(f"\nmAP: {results.mAP():.3f}")
+```
+
+### Cell 15 — markdown
+```markdown
+## Analyze Errors
+
+The evaluation patches view lets you examine individual true positives,
+false positives, and false negatives. This is invaluable for understanding
+where your model succeeds and fails.
+```
+
+### Cell 16 — code
+```python
+# Convert to evaluation patches
+patches = dataset.to_evaluation_patches("eval")
+print(patches.count_values("type"))
+
+# View false positives in the App
+fp_view = patches.match(F("type") == "fp")
+session.view = fp_view
+```
+
+### Cell 17 — markdown
+```markdown
+## Export for Training
+
+Export the dataset to YOLOv5 format, ready for fine-tuning or
+training a custom model.
+```
+
+### Cell 18 — code
+```python
+import fiftyone.types as fot
+
+dataset.export(
+    export_dir="/tmp/detection-getting-started-export",
+    dataset_type=fot.YOLOv5Dataset,
+    label_field="ground_truth",
+)
+
+print("Exported to /tmp/detection-getting-started-export/")
+```
+
+### Cell 19 — markdown
+```markdown
+## Conclusion
+
+In this notebook, you learned how to:
+
+- **Load** a COCO detection dataset with `foz.load_zoo_dataset()`
+- **Explore** data visually in the FiftyOne App
+- **Run inference** with YOLOv8 using `dataset.apply_model()`
+- **Evaluate** predictions with COCO metrics (`evaluate_detections`)
+- **Analyze** TP/FP/FN with evaluation patches
+- **Export** to YOLO format for training
+
+**Next Steps:**
+- [Embeddings Visualization](https://docs.voxel51.com/tutorials/image_embeddings.html) — Visualize your dataset in embedding space
+- [Finding Annotation Mistakes](https://docs.voxel51.com/tutorials/detection_mistakes.html) — Use brain methods to find labeling errors
+- [FiftyOne User Guide](https://docs.voxel51.com/user_guide/index.html) — Deep dive into FiftyOne capabilities
+```
+
+### Cell 20 — code
+```python
+# Cleanup
+fo.delete_dataset("detection-getting-started")
+```
+
+---
+
+## Template: Image Classification
+
+| Cell | Type | Content |
+|---|---|---|
+| 0 | markdown | Title: `# Getting Started with Image Classification in FiftyOne` + metadata + overview |
+| 1 | markdown | What You Will Learn: load CIFAR-10, explore class balance, run ResNet-50, evaluate, find errors |
+| 2 | code | `!pip install -q fiftyone` |
+| 3 | markdown | `## Setup` + import explanation |
+| 4 | code | Imports: `fo`, `foz`, `F` |
+| 5 | markdown | `## Load the Dataset` + explain CIFAR-10 (10 classes, 60K images) |
+| 6 | code | `foz.load_zoo_dataset("cifar10", split="test", max_samples=500)` + `print(dataset)` |
+| 7 | markdown | `## Explore in the FiftyOne App` |
+| 8 | code | `session = fo.launch_app(dataset)` |
+| 9 | markdown | `## Class Distribution` |
+| 10 | code | `dataset.count_values("ground_truth.label")` |
+| 11 | markdown | `## Run Classification` + explain ResNet-50 |
+| 12 | code | Load `resnet50-imagenet-torch` + `dataset.apply_model(...)` + `session.view = dataset.view()` |
+| 13 | markdown | `## Evaluate Predictions` |
+| 14 | code | `dataset.evaluate_classifications(...)` + `results.print_report()` |
+| 15 | markdown | `## Find Misclassified Images` |
+| 16 | code | `dataset.match(F("eval") == False)` + `session.view` |
+| 17 | markdown | `## Conclusion` + summary + next steps |
+| 18 | code | `fo.delete_dataset("classification-getting-started")` |
+
+---
+
+## Template: Image Similarity & Embeddings
+
+| Cell | Type | Content |
+|---|---|---|
+| 0 | markdown | Title: `# Getting Started with Image Similarity in FiftyOne` + metadata + overview |
+| 1 | markdown | What You Will Learn: load quickstart, compute CLIP embeddings, UMAP visualization, find outliers |
+| 2 | code | `!pip install -q fiftyone umap-learn` |
+| 3 | markdown | `## Setup` + import explanation |
+| 4 | code | Imports: `fo`, `foz`, `fob` |
+| 5 | markdown | `## Load the Dataset` + explain quickstart dataset |
+| 6 | code | `foz.load_zoo_dataset("quickstart")` + `print(dataset)` |
+| 7 | markdown | `## Explore in the FiftyOne App` |
+| 8 | code | `session = fo.launch_app(dataset)` |
+| 9 | markdown | `## Compute Embeddings and Visualization` + explain CLIP + UMAP |
+| 10 | code | `fob.compute_similarity(...)` + `fob.compute_visualization(...)` + `session.view` |
+| 11 | markdown | `## Find Outliers with Uniqueness` + explain uniqueness scoring |
+| 12 | code | `fob.compute_uniqueness(...)` + sort by uniqueness + `session.view` |
+| 13 | markdown | `## Conclusion` + summary + next steps |
+| 14 | code | `fo.delete_dataset("similarity-getting-started")` |
+
+## Adaptation Guidelines
+
+When creating a new getting-started notebook for a domain not listed above:
+
+1. **Pick a zoo dataset** that represents the domain well
+2. **Choose an appropriate model** from the Model Zoo
+3. **Use the matching evaluation method** (detections → `evaluate_detections`, classifications → `evaluate_classifications`)
+4. **Keep it under 22 cells** — brevity is key for beginners
+5. **Explain every concept** as if the reader has never used FiftyOne
+6. **Include App screenshots guidance** — tell users what to look for
+7. **Include metadata** in the title cell: level, time estimate, prerequisites
+
+## Guide Packaging
+
+When creating a multi-notebook getting-started guide (not just a single notebook), follow this structure.
+
+### Folder Structure
+
+```
+docs/source/getting_started/{guide_name}/
+├── index.rst             # Landing page: title, video, objectives, prerequisites, toctree
+├── summary.rst           # Recap, exercises, resources, feedback
+├── requirements.txt      # Exact dependencies + Python version
+├── 01_intro.ipynb        # Numbered, self-contained notebooks
+├── 02_explore.ipynb
+└── 03_evaluate.ipynb
+```
+
+### Notebook Requirements
+
+- **Numbering:** `01_`, `02_`, `03_` — sequential, each independently runnable
+- **Metadata** in title cell: level (Beginner/Intermediate/Advanced), time estimate, prerequisites, recommended reads
+- **Images:** `.webp` format on CDN: `![name](https://cdn.voxel51.com/getting_started_{guide_name}/notebook{N}/{file}.webp)`
+- **Upload:** `gsutil cp /path/to/file.webp gs://voxel51-static-cdn-91225dde9e4f2d89/getting_started_{guide_name}/notebook{N}/`
+- **Dependencies:** exact versions in `requirements.txt`; don't import all libraries in the first notebook
+
+### index.rst
+
+Must include: title, short description, embedded video (optional), learning objectives, prerequisites, Python/library/OS versions, guide overview with linked steps, toctree with all notebooks + summary.
+
+Example card for the global getting-started index:
+```rst
+.. customcarditem::
+   :header: {Guide Name}
+   :description: {Short description}
+   :link: {guide_name}/index.html
+   :image: ../_static/images/guides/{guide_name}.png
+   :tags: vision, beginner
+```
+
+### summary.rst
+
+Must include: congratulations message, step-by-step recap, suggested exercises, resources and further reading, next steps, feedback section.
+
+### Quality Checklist
+
+- [ ] Notebooks numbered and individually runnable
+- [ ] Metadata filled (level, time, prerequisites)
+- [ ] Images in `.webp` on CDN, cover image in `_static/images/guides/`
+- [ ] Code follows FiftyOne conventions
+- [ ] `index.rst` and `summary.rst` complete
+- [ ] `requirements.txt` with exact versions
+- [ ] Links and toctrees verified

--- a/skills/fiftyone-create-notebook/NOTEBOOK-STRUCTURE.md
+++ b/skills/fiftyone-create-notebook/NOTEBOOK-STRUCTURE.md
@@ -1,0 +1,235 @@
+# Notebook Structure Patterns
+
+## Contents
+- [Cell Rules](#cell-rules)
+- [Pipeline Stage Cell Templates](#pipeline-stage-cell-templates)
+- [Narrative Flow Guidelines](#narrative-flow-guidelines)
+
+---
+
+This document defines the **cell structure** for each pipeline stage. It tells you HOW to structure cells and WHERE to find code patterns — without duplicating code that already exists in other skills and documentation.
+
+## Cell Rules
+
+1. **Every code cell MUST be preceded by a markdown cell** that explains what and why
+2. **Markdown cells** should explain the purpose, not just describe the code
+3. **Code cells** should be under 15 lines, one concept per cell
+4. **First cell** is always a markdown title + description
+5. **Last code cell** is always cleanup (delete temporary datasets, close sessions)
+6. **Include `print()` calls** so users see output when running the notebook
+
+## Pipeline Stage Cell Templates
+
+### 1. Setup Section (3 cells)
+
+| Cell | Type | Content Pattern |
+|---|---|---|
+| N | code | `!pip install fiftyone [extras]` — preceded by previous section's markdown. Only include packages actually used (e.g., `ultralytics` for YOLO, `umap-learn` for UMAP) |
+| N+1 | markdown | `## Setup` + brief explanation of what libraries are used and why |
+| N+2 | code | All imports in one cell, following FiftyOne conventions |
+
+**Import cell pattern:**
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+# Add only what the notebook actually uses:
+# import fiftyone.brain as fob      # if using brain methods
+# import fiftyone.types as fot      # if exporting
+# from fiftyone import ViewField as F  # if filtering
+```
+
+**Code pattern source:** See SKILL.md "Code Pattern Sources" table for related skills. Fetch `https://docs.voxel51.com/llms.txt` for current API.
+
+### 2. Data Loading Section (2 cells)
+
+| Cell | Type | Content Pattern |
+|---|---|---|
+| N | markdown | `## Load Dataset` + explain what dataset, why it's a good choice, what it contains |
+| N+1 | code | Load dataset + `print(dataset)` + `print(dataset.first())` in one cell |
+
+**Zoo dataset pattern:**
+```python
+dataset = foz.load_zoo_dataset(
+    "dataset-name",
+    split="validation",
+    max_samples=200,
+    seed=51,
+    dataset_name="notebook-name",
+)
+print(dataset)
+```
+
+**Code pattern source:** Fetch `https://docs.voxel51.com/llms.txt` for all dataset loading methods.
+
+### 3. Exploration Section (3-4 cells)
+
+| Cell | Type | Content Pattern |
+|---|---|---|
+| N | markdown | `## Explore the Dataset` + explain the value of visual exploration |
+| N+1 | code | `session = fo.launch_app(dataset)` |
+| N+2 | markdown | Brief note about what to look for in the App |
+| N+3 | code | Statistics: `count_values()`, `distinct()`, `bounds()`, sorting |
+
+**Statistics patterns:**
+```python
+# Class distribution
+counts = dataset.count_values("field.detections.label")
+print(dict(sorted(counts.items(), key=lambda x: -x[1])[:10]))
+
+# Dataset overview
+print(f"Samples: {len(dataset)}")
+print(f"Classes: {dataset.distinct('field.detections.label')}")
+```
+
+**Code pattern source:** Fetch `https://docs.voxel51.com/llms.txt` for aggregation methods (count_values, distinct, bounds, mean, std, histogram_values).
+
+### 4. Brain Methods Section (2-4 cells)
+
+| Cell | Type | Content Pattern |
+|---|---|---|
+| N | markdown | `## [Brain Method Name]` + explain what it does and why it's useful |
+| N+1 | code | Compute brain method + view results (merge related operations) |
+| N+2 | markdown | (Optional) Explain next analysis step |
+| N+3 | code | (Optional) Additional analysis or filtering |
+
+**Brain method patterns use the Python SDK directly in notebooks:**
+```python
+import fiftyone.brain as fob
+
+# Compute similarity (creates embeddings index)
+fob.compute_similarity(dataset, brain_key="sim", model="clip-vit-base32-torch")
+
+# Compute visualization (UMAP/t-SNE)
+fob.compute_visualization(dataset, brain_key="viz", method="umap")
+
+# Compute uniqueness (outlier scoring)
+fob.compute_uniqueness(dataset, uniqueness_field="uniqueness")
+```
+
+**Code pattern source:** Fetch `https://docs.voxel51.com/llms.txt` for brain methods.
+
+### 5. Inference Section (2 cells)
+
+| Cell | Type | Content Pattern |
+|---|---|---|
+| N | markdown | `## Run Model Inference` + explain what model does and why this one was chosen |
+| N+1 | code | Load model + apply to dataset + view predictions (`session.view = dataset.view()`) |
+
+**Inference pattern:**
+```python
+model = foz.load_zoo_model("model-name")
+dataset.apply_model(model, label_field="predictions")
+print(dataset)
+```
+
+**Common models by task** (not exhaustive — fetch `https://docs.voxel51.com/llms.txt` for full model zoo):
+- Detection: `yolov8n-coco-torch`, `faster-rcnn-resnet50-fpn-coco-torch`
+- Classification: `resnet50-imagenet-torch`, `mobilenet-v2-imagenet-torch`
+- Segmentation: `deeplabv3-resnet101-coco-torch`, `sam-vit-base-torch`
+- Embeddings: `clip-vit-base32-torch`, `dinov2-vits14-torch`
+
+### 6. Evaluation Section (4 cells)
+
+| Cell | Type | Content Pattern |
+|---|---|---|
+| N | markdown | `## Evaluate Predictions` + explain evaluation methodology |
+| N+1 | code | Run evaluation + print report (+ confusion matrix if relevant) |
+| N+2 | markdown | `## Analyze Errors` + explain TP/FP/FN concept |
+| N+3 | code | Evaluation patches view + filter to errors |
+
+**Evaluation pattern:**
+```python
+results = dataset.evaluate_detections(
+    "predictions",
+    gt_field="ground_truth",
+    eval_key="eval",
+    method="coco",
+    compute_mAP=True,
+)
+results.print_report()
+print(f"mAP: {results.mAP():.3f}")
+```
+
+**Patches pattern:**
+```python
+patches = dataset.to_evaluation_patches("eval")
+print(patches.count_values("type"))
+
+fp_view = patches.match(F("type") == "fp")
+session.view = fp_view
+```
+
+**Evaluation methods by label type:**
+- `Detections` → `dataset.evaluate_detections()` (methods: "coco", "open-images")
+- `Classification` → `dataset.evaluate_classifications()` (methods: "simple", "top-k", "binary")
+- `Segmentation` → `dataset.evaluate_segmentations()` (methods: "simple")
+- `Regression` → `dataset.evaluate_regressions()` (methods: "simple")
+
+**Code pattern source:** Fetch `https://docs.voxel51.com/llms.txt` for evaluation API.
+
+### 7. Export Section (2 cells)
+
+| Cell | Type | Content Pattern |
+|---|---|---|
+| N | markdown | `## Export Dataset` + explain the target format and why |
+| N+1 | code | Export call |
+
+**Export pattern:**
+```python
+import fiftyone.types as fot
+
+dataset.export(
+    export_dir="/tmp/export-dir",
+    dataset_type=fot.COCODetectionDataset,
+    label_field="ground_truth",
+)
+```
+
+**Common export types:**
+- `fot.COCODetectionDataset` - COCO JSON format
+- `fot.YOLOv5Dataset` - YOLOv5 format
+- `fot.VOCDetectionDataset` - Pascal VOC XML
+- `fot.CVATImageDataset` - CVAT format
+- `fot.CSVDataset` - CSV
+
+**Code pattern source:** Fetch `https://docs.voxel51.com/llms.txt` for export types.
+
+### 8. Conclusion Section (2 cells)
+
+| Cell | Type | Content Pattern |
+|---|---|---|
+| N | markdown | `## Conclusion` + summary of what was covered, key takeaways, next steps with links |
+| N+1 | code | Cleanup: `fo.delete_dataset("dataset-name")` |
+
+**Conclusion markdown pattern:**
+```markdown
+## Conclusion
+
+In this notebook, you learned how to:
+- [Bullet point for each major section]
+
+**Next Steps:**
+- [Link to related tutorial](https://docs.voxel51.com/tutorials/...)
+- [Link to relevant docs](https://docs.voxel51.com/user_guide/...)
+- [Link to FiftyOne community](https://discord.gg/fiftyone-community)
+```
+
+## Narrative Flow Guidelines
+
+### Getting Started Notebooks
+- **Tone:** Welcoming, encouraging, no jargon without explanation
+- **Pacing:** Slow, one concept at a time
+- **Markdown:** Explain every concept as if the reader is new to FiftyOne
+- **App guidance:** Tell users what to look for in the App ("Notice how the bounding boxes...")
+
+### Tutorial Notebooks
+- **Tone:** Technical but accessible, assumes basic FiftyOne knowledge
+- **Pacing:** Moderate, can combine related concepts
+- **Markdown:** Explain the "why" behind each technique, include real-world motivation
+- **Analysis:** Include interpretation of results ("The high number of false positives suggests...")
+
+### Recipe Notebooks
+- **Tone:** Direct, concise, no preamble
+- **Pacing:** Fast, get to the solution quickly
+- **Markdown:** Minimal explanation, focus on the code
+- **Variations:** End with alternative approaches as bullet points

--- a/skills/fiftyone-create-notebook/RECIPE-TEMPLATES.md
+++ b/skills/fiftyone-create-notebook/RECIPE-TEMPLATES.md
@@ -1,0 +1,426 @@
+# Recipe Templates
+
+## Contents
+- [Canonical Structure](#canonical-structure)
+- [Key Differences from Other Types](#key-differences-from-other-types)
+- [Recipe: Export Dataset to COCO Format](#recipe-export-dataset-to-coco-format)
+- [Recipe: Remove Duplicate Images](#recipe-remove-duplicate-images)
+- [Recipe: Filter Low-Confidence Detections](#recipe-filter-low-confidence-detections)
+- [Recipe: Compare Two Models Side by Side](#recipe-compare-two-models-side-by-side)
+- [Recipe: Compute and Visualize Embeddings](#recipe-compute-and-visualize-embeddings)
+- [Recipe: Merge Two Datasets](#recipe-merge-two-datasets)
+- [Recipe: Add Custom Metadata to Samples](#recipe-add-custom-metadata-to-samples)
+- [Adaptation Guidelines](#adaptation-guidelines)
+
+---
+
+**Target audience:** Practitioners who know FiftyOne and need a quick solution
+**Duration:** 5-10 minutes
+**Cell count:** 6-10 cells
+**Scope:** Solve one specific problem, minimal explanation
+
+The recipes below are **structural examples** — follow the canonical structure but adapt the specific operations, field names, and parameters to the user's request. Fetch `https://docs.voxel51.com/llms.txt` for the correct API for any task.
+
+## Canonical Structure
+
+| Cell | Type | Content |
+|---|---|---|
+| 0 | markdown | Title (verb phrase) + one sentence description |
+| 1 | code | pip install (if needed) + all imports in one cell |
+| 2 | code | Load or create data |
+| 3 | markdown | Brief explanation of approach (2-3 sentences max) |
+| 4 | code | Core solution |
+| 5 | code | Verify result |
+| 6 | markdown | Variations (2-4 bullet points with alternative approaches) |
+
+## Key Differences from Other Types
+
+- **No learning goals section** — the title tells you what you get
+- **Minimal markdown** — just enough to understand the approach
+- **Imports + pip in one cell** — get to the solution fast
+- **Variations at the end** — show related approaches as bullet points, not full cells
+- **No App visualization required** — include only if relevant to the recipe
+
+## Recipe: Export Dataset to COCO Format
+
+### Cell 0 — markdown
+```markdown
+# Export a FiftyOne Dataset to COCO Format
+
+Export any FiftyOne dataset with detection labels to the COCO JSON format,
+ready for training or sharing.
+```
+
+### Cell 1 — code
+```python
+import fiftyone as fo
+import fiftyone.types as fot
+```
+
+### Cell 2 — code
+```python
+# Load your dataset (replace with your dataset name)
+dataset = fo.load_dataset("my-dataset")
+print(dataset)
+```
+
+### Cell 3 — markdown
+```markdown
+FiftyOne's `export()` method converts datasets to standard formats. For COCO,
+this creates the `labels.json` file and copies images to the export directory.
+```
+
+### Cell 4 — code
+```python
+dataset.export(
+    export_dir="/tmp/coco-export",
+    dataset_type=fot.COCODetectionDataset,
+    label_field="ground_truth",
+)
+```
+
+### Cell 5 — code
+```python
+import os
+
+export_dir = "/tmp/coco-export"
+print(f"Exported files:")
+for f in os.listdir(export_dir):
+    path = os.path.join(export_dir, f)
+    if os.path.isdir(path):
+        print(f"  {f}/ ({len(os.listdir(path))} files)")
+    else:
+        print(f"  {f}")
+```
+
+### Cell 6 — markdown
+```markdown
+**Variations:**
+- Export only labels (no images): `dataset.export(..., export_media=False)`
+- Export a filtered view: `view = dataset.match(F("tag") == "train"); view.export(...)`
+- Export to YOLO format: `dataset_type=fot.YOLOv5Dataset`
+- Export to VOC format: `dataset_type=fot.VOCDetectionDataset`
+```
+
+---
+
+## Recipe: Remove Duplicate Images
+
+### Cell 0 — markdown
+```markdown
+# Remove Duplicate Images from a Dataset
+
+Find and remove exact or near-duplicate images using FiftyOne's brain methods.
+```
+
+### Cell 1 — code
+```python
+import fiftyone as fo
+import fiftyone.brain as fob
+```
+
+### Cell 2 — code
+```python
+dataset = fo.load_dataset("my-dataset")
+print(f"Samples before dedup: {len(dataset)}")
+```
+
+### Cell 3 — markdown
+```markdown
+Compute image embeddings and find near-duplicates within a distance threshold.
+Lower thresholds are stricter (closer to exact match).
+```
+
+### Cell 4 — code
+```python
+# Compute similarity index
+fob.compute_similarity(dataset, brain_key="sim", model="clip-vit-base32-torch")
+
+# Find near-duplicates (threshold 0.3 = visually similar)
+results = fob.compute_near_duplicates(dataset, brain_key="sim", thresh=0.3)
+print(f"Found {len(results.near_duplicates)} near-duplicate groups")
+```
+
+### Cell 5 — code
+```python
+# Remove duplicates, keeping one from each group
+dups = results.duplicates_view()
+dataset.delete_samples(dups)
+print(f"Samples after dedup: {len(dataset)}")
+```
+
+### Cell 6 — markdown
+```markdown
+**Variations:**
+- Find exact duplicates only: `fob.compute_exact_duplicates(dataset)`
+- Adjust threshold: `thresh=0.1` (stricter) or `thresh=0.5` (more permissive)
+- Review before deleting: `session = fo.launch_app(dups)` to inspect flagged images
+- Use DINOv2 for visual-only similarity: `model="dinov2-vits14-torch"`
+```
+
+---
+
+## Recipe: Filter Low-Confidence Detections
+
+### Cell 0 — markdown
+```markdown
+# Filter Low-Confidence Detections
+
+Remove predictions below a confidence threshold from your dataset's detection field.
+```
+
+### Cell 1 — code
+```python
+import fiftyone as fo
+from fiftyone import ViewField as F
+```
+
+### Cell 2 — code
+```python
+dataset = fo.load_dataset("my-dataset")
+print(f"Total detections: {dataset.count('predictions.detections')}")
+```
+
+### Cell 3 — markdown
+```markdown
+Use `filter_labels()` to keep only detections above a confidence threshold.
+This creates a view — the underlying data is not modified.
+```
+
+### Cell 4 — code
+```python
+# Keep only detections with confidence >= 0.5
+high_conf_view = dataset.filter_labels(
+    "predictions", F("confidence") >= 0.5
+)
+print(f"Detections after filtering: {high_conf_view.count('predictions.detections')}")
+```
+
+### Cell 5 — code
+```python
+# To permanently remove low-confidence detections, save the filtered view
+high_conf_view.save("predictions")
+print(f"Saved. Detections: {dataset.count('predictions.detections')}")
+```
+
+### Cell 6 — markdown
+```markdown
+**Variations:**
+- Filter by class: `F("label") == "person"`
+- Combine filters: `(F("confidence") >= 0.5) & (F("label").is_in(["person", "car"]))`
+- View as a temporary filter (no save): use the view directly in the App
+```
+
+---
+
+## Recipe: Compare Two Models Side by Side
+
+### Cell 0 — markdown
+```markdown
+# Compare Two Models Side by Side
+
+Run two detection models on the same dataset and compare their predictions
+using evaluation metrics.
+```
+
+### Cell 1 — code
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+```
+
+### Cell 2 — code
+```python
+dataset = fo.load_dataset("my-dataset")
+print(dataset)
+```
+
+### Cell 3 — markdown
+```markdown
+Apply two models with different label fields, then evaluate each against
+ground truth to compare metrics.
+```
+
+### Cell 4 — code
+```python
+# Run Model A
+model_a = foz.load_zoo_model("yolov8n-coco-torch")
+dataset.apply_model(model_a, label_field="model_a")
+
+# Run Model B
+model_b = foz.load_zoo_model("yolov8m-coco-torch")
+dataset.apply_model(model_b, label_field="model_b")
+```
+
+### Cell 5 — code
+```python
+# Evaluate both
+results_a = dataset.evaluate_detections("model_a", gt_field="ground_truth", eval_key="eval_a", method="coco", compute_mAP=True)
+results_b = dataset.evaluate_detections("model_b", gt_field="ground_truth", eval_key="eval_b", method="coco", compute_mAP=True)
+
+print(f"Model A (YOLOv8n) mAP: {results_a.mAP():.3f}")
+print(f"Model B (YOLOv8m) mAP: {results_b.mAP():.3f}")
+```
+
+### Cell 6 — markdown
+```markdown
+**Variations:**
+- Compare different model families: Faster R-CNN vs YOLO
+- Compare at different IoU thresholds: `iou=0.25` vs `iou=0.75`
+- View samples where models disagree: filter by different TP/FP counts
+```
+
+---
+
+## Recipe: Compute and Visualize Embeddings
+
+### Cell 0 — markdown
+```markdown
+# Compute and Visualize Image Embeddings
+
+Compute image embeddings and visualize your dataset in 2D using UMAP.
+```
+
+### Cell 1 — code
+```python
+import fiftyone as fo
+import fiftyone.brain as fob
+```
+
+### Cell 2 — code
+```python
+dataset = fo.load_dataset("my-dataset")
+print(dataset)
+```
+
+### Cell 3 — markdown
+```markdown
+Compute CLIP embeddings and reduce to 2D with UMAP for visualization
+in the FiftyOne App Embeddings panel.
+```
+
+### Cell 4 — code
+```python
+fob.compute_similarity(dataset, brain_key="sim", model="clip-vit-base32-torch")
+fob.compute_visualization(dataset, brain_key="viz", method="umap")
+```
+
+### Cell 5 — code
+```python
+session = fo.launch_app(dataset)
+# Open the Embeddings panel in the App to explore the 2D visualization
+```
+
+### Cell 6 — markdown
+```markdown
+**Variations:**
+- Use DINOv2 for visual-only similarity: `model="dinov2-vits14-torch"`
+- Use t-SNE instead of UMAP: `method="tsne"`
+- Color by field in the Embeddings panel: select a label field in the dropdown
+- Compute uniqueness scores: `fob.compute_uniqueness(dataset)`
+```
+
+---
+
+## Recipe: Merge Two Datasets
+
+### Cell 0 — markdown
+```markdown
+# Merge Two FiftyOne Datasets
+
+Combine samples from two datasets into a single dataset.
+```
+
+### Cell 1 — code
+```python
+import fiftyone as fo
+```
+
+### Cell 2 — code
+```python
+dataset_a = fo.load_dataset("dataset-a")
+dataset_b = fo.load_dataset("dataset-b")
+print(f"Dataset A: {len(dataset_a)} samples")
+print(f"Dataset B: {len(dataset_b)} samples")
+```
+
+### Cell 3 — markdown
+```markdown
+Use `merge_samples()` to combine datasets. Samples with matching filepaths
+will be merged (their labels combined); new samples will be added.
+```
+
+### Cell 4 — code
+```python
+dataset_a.merge_samples(dataset_b)
+print(f"Merged dataset: {len(dataset_a)} samples")
+```
+
+### Cell 5 — markdown
+```markdown
+**Variations:**
+- Create a new merged dataset: `merged = fo.Dataset("merged"); merged.merge_samples(dataset_a); merged.merge_samples(dataset_b)`
+- Merge only specific fields: `dataset_a.merge_samples(dataset_b, fields=["ground_truth"])`
+- Skip existing: `dataset_a.merge_samples(dataset_b, skip_existing=True)`
+```
+
+---
+
+## Recipe: Add Custom Metadata to Samples
+
+### Cell 0 — markdown
+```markdown
+# Add Custom Metadata to Samples
+
+Add custom fields (scores, categories, tags) to your dataset samples
+programmatically.
+```
+
+### Cell 1 — code
+```python
+import fiftyone as fo
+```
+
+### Cell 2 — code
+```python
+dataset = fo.load_dataset("my-dataset")
+print(dataset)
+```
+
+### Cell 3 — markdown
+```markdown
+FiftyOne samples support dynamic fields. Set any attribute on a sample
+and call `sample.save()` to persist it.
+```
+
+### Cell 4 — code
+```python
+# Add a custom field to all samples
+for sample in dataset:
+    sample["quality_score"] = len(sample.filepath)  # placeholder logic
+    sample["source"] = "batch_1"
+    sample.save()
+
+print(dataset.count_values("source"))
+```
+
+### Cell 5 — markdown
+```markdown
+**Variations:**
+- Bulk set with `set_values()`: `dataset.set_values("field", values_list)`
+- Tag samples: `dataset.tag_samples("my-tag")`
+- Add computed fields: use `dataset.apply_model()` or brain methods
+- Delete a field: `dataset.delete_sample_field("field_name")`
+```
+
+## Adaptation Guidelines
+
+When creating a new recipe:
+
+1. **Title must be a verb phrase** — "Export...", "Filter...", "Compute...", "Remove..."
+2. **One sentence description** — what it does and when to use it
+3. **Get to the code fast** — imports + data in the first 2 cells
+4. **Core solution in one cell** — the main code block should be copy-pasteable
+5. **End with variations** — bullet points showing related approaches
+6. **No App visualization unless essential** — recipes are about code, not exploration
+7. **Keep it under 10 cells** — if it needs more, it's a tutorial, not a recipe

--- a/skills/fiftyone-create-notebook/SKILL.md
+++ b/skills/fiftyone-create-notebook/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: fiftyone-create-notebook
+description: Creates Jupyter notebooks for FiftyOne workflows including getting-started guides, tutorials, recipes, and full ML pipelines. Use when creating notebooks, writing tutorials, building demos, or generating FiftyOne walkthroughs covering data loading, exploration, inference, evaluation, and export.
+---
+
+# Create FiftyOne Notebooks
+
+## Contents
+- [Key Directives](#key-directives)
+- [Complete Workflow](#complete-workflow)
+- [Notebook Structure Reference](#notebook-structure-reference)
+- [Common Use Cases](#common-use-cases)
+- [Troubleshooting](#troubleshooting)
+- [Best Practices](#best-practices)
+- [Resources](#resources)
+
+## Key Directives
+
+**ALWAYS follow these rules:**
+
+### 1. Determine notebook type first
+
+Classify the user's request before anything else:
+
+| User Request Pattern | Type | Template |
+|---|---|---|
+| "getting started", "beginner", "intro", "first notebook" | Getting Started | [GETTING-STARTED-TEMPLATES.md](GETTING-STARTED-TEMPLATES.md) |
+| "tutorial", "how to use X", "deep dive", "demonstrate X" | Tutorial | [TUTORIAL-TEMPLATES.md](TUTORIAL-TEMPLATES.md) |
+| "recipe", "quick", "snippet", "how do I X" | Recipe | [RECIPE-TEMPLATES.md](RECIPE-TEMPLATES.md) |
+| "full pipeline", "end to end", "ML pipeline", "complete workflow" | Full Pipeline | [GETTING-STARTED-TEMPLATES.md](GETTING-STARTED-TEMPLATES.md) with all stages |
+
+If ambiguous, ask the user.
+
+### 2. Create the notebook file before adding cells
+
+Use the Write tool to create a valid empty `.ipynb` file first:
+
+```json
+{
+  "nbformat": 4,
+  "nbformat_minor": 2,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.0"
+    }
+  },
+  "cells": []
+}
+```
+
+Then use `NotebookEdit` with `edit_mode: "insert"` to add cells.
+
+### 3. Follow FiftyOne code conventions
+
+All generated code must use standard FiftyOne import aliases:
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+import fiftyone.brain as fob
+import fiftyone.types as fot
+from fiftyone import ViewField as F
+```
+
+See the "Code Pattern Sources" table below for full conventions.
+
+### 4. Build notebooks cell-by-cell
+
+Use `NotebookEdit` with `edit_mode: "insert"` for every cell. Build top-to-bottom using `cell_id` chaining: insert the first cell without `cell_id` (inserts at beginning), then read the notebook to get its `cell_id`, and insert each subsequent cell with `cell_id` set to the previous cell's ID. This ensures correct ordering.
+
+**Critical:** Without `cell_id`, every insert goes to the **beginning** of the notebook, resulting in reversed cell order.
+
+**Never** write the entire `.ipynb` JSON at once. Incremental cell insertion allows verification and correction.
+
+### 5. Always include App visualization
+
+Every notebook must include at least one cell with:
+
+```python
+session = fo.launch_app(dataset)
+```
+
+FiftyOne's core value is visual exploration. Notebooks without App visualization miss the point.
+
+### 6. Use zoo datasets when user has no data
+
+For getting-started and tutorial notebooks, default to `foz.load_zoo_dataset()` so users can run the notebook without bringing their own data. For recipes and custom pipelines, support both zoo and user data.
+
+### 7. Precede every code cell with a markdown cell
+
+Never place two code cells in a row without a markdown cell in between. The markdown cell explains **what** the code does and **why**. This is critical for tutorials and getting-started guides. Recipes are exempt — consecutive code cells are permitted for brevity (imports + load data, core solution + verify).
+
+### 8. Present outline before generating
+
+Before creating any cells, draft a notebook outline showing:
+- Section headings
+- Cell types (markdown/code)
+- Brief description of each cell
+
+Get user approval before generating.
+
+### 9. Fetch current API documentation
+
+When generating code, fetch `https://docs.voxel51.com/llms.txt` for the latest FiftyOne API patterns. This ensures generated code uses current APIs and avoids deprecated patterns.
+
+### 10. Verify after generation
+
+After all cells are inserted, read the notebook back with the Read tool to verify:
+- Cells are in correct order
+- Markdown/code alternation is maintained
+- Import aliases are correct
+- Narrative flow is logical
+
+## Complete Workflow
+
+### Phase 1: Requirements
+
+Gather information before designing the notebook:
+
+1. **Classify notebook type** — Use the decision matrix from Directive 1. Ask the user if ambiguous.
+2. **Determine domain and task** — Ask or infer what ML task the notebook covers. Common domains include:
+   - Object Detection
+   - Image Classification
+   - Instance/Semantic Segmentation
+   - Embeddings & Similarity
+   - Data Curation (duplicates, outliers, annotation mistakes)
+   - Video analysis, 3D point clouds, or any other FiftyOne-supported workflow
+3. **Determine data source:**
+   - **Zoo dataset** (recommended for tutorials): `foz.load_zoo_dataset("coco-2017", ...)`
+   - **User's local data**: `fo.Dataset.from_dir(...)`
+   - **Hugging Face Hub**: `foz.load_zoo_dataset("https://huggingface.co/datasets/...", ...)`
+   - **Quickstart**: `foz.load_zoo_dataset("quickstart")`
+4. **Determine pipeline stages:**
+
+| Stage | Description | Always Include? |
+|---|---|---|
+| Data Loading | Load/create dataset | Yes |
+| Exploration | App, stats, filtering | Yes |
+| Brain Methods | Embeddings, uniqueness, duplicates | If relevant |
+| Inference | Model predictions | If relevant |
+| Evaluation | Metrics, TP/FP/FN analysis | If predictions + ground truth |
+| Export | Save to format | Optional |
+
+5. **Confirm with user** — Present a summary:
+   - Notebook type: [Getting Started / Tutorial / Recipe / Full Pipeline]
+   - Domain: [Detection / Classification / ...]
+   - Data source: [Zoo dataset name / User path / HF URL]
+   - Pipeline stages: [Load, Explore, Infer, Evaluate, Export]
+   - Estimated cells: [N]
+
+### Phase 2: Design
+
+1. **Read the appropriate template doc** as a structural guide (adapt to the user's domain — do not copy specific datasets, models, or field names from the examples):
+   - [GETTING-STARTED-TEMPLATES.md](GETTING-STARTED-TEMPLATES.md) for getting-started and full pipeline
+   - [TUTORIAL-TEMPLATES.md](TUTORIAL-TEMPLATES.md) for tutorials
+   - [RECIPE-TEMPLATES.md](RECIPE-TEMPLATES.md) for recipes
+2. **Fetch API documentation** — Fetch `https://docs.voxel51.com/llms.txt` using the WebFetch tool for current FiftyOne API patterns. This is the authoritative source for SDK usage.
+3. **Draft notebook outline** — Create a numbered list of cells with cell number, type (markdown/code), and content summary:
+```
+0. [markdown] Title + description
+1. [markdown] What You Will Learn
+2. [code] pip install
+3. [markdown] ## Setup
+4. [code] Imports
+5. [markdown] ## Load Dataset
+6. [code] Load from zoo + print dataset info
+...
+```
+4. **Present outline for approval** — Show the outline to the user. Wait for approval before generating.
+
+### Phase 3: Generation
+
+1. **Create empty notebook file:**
+```python
+# Use Write tool
+Write(
+    file_path="/path/to/notebook.ipynb",
+    content='{"nbformat": 4, "nbformat_minor": 2, "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python", "version": "3.10.0"}}, "cells": []}'
+)
+```
+Ask the user for the notebook file path, or suggest a default based on the title.
+
+2. **Add cells with NotebookEdit using `cell_id` chaining:**
+
+Insert the first cell without `cell_id` (goes to beginning), then read the notebook to get the assigned `cell_id`. Each subsequent cell uses `cell_id` of the previous cell:
+```
+# First cell — no cell_id, inserts at beginning
+NotebookEdit(
+    notebook_path="/path/to/notebook.ipynb",
+    new_source="# Title\n\nDescription paragraph.",
+    cell_type="markdown",
+    edit_mode="insert"
+)
+
+# Read notebook to get the first cell's ID (e.g., "cell-0")
+Read(file_path="/path/to/notebook.ipynb")
+
+# Second cell — chain after cell-0
+NotebookEdit(
+    notebook_path="/path/to/notebook.ipynb",
+    cell_id="cell-0",
+    new_source="!pip install -q fiftyone",
+    cell_type="code",
+    edit_mode="insert"
+)
+
+# Third cell — chain after cell-1
+NotebookEdit(
+    notebook_path="/path/to/notebook.ipynb",
+    cell_id="cell-1",
+    new_source="import fiftyone as fo",
+    cell_type="code",
+    edit_mode="insert"
+)
+```
+Continue chaining: each new cell's `cell_id` = previous cell's ID (cell-0, cell-1, cell-2, ...).
+
+**Cell content guidelines:**
+- Keep code cells under 15 lines
+- One concept per code cell
+- Include inline comments for non-obvious operations
+- Use `print()` liberally so users see output
+- Include `# Expected output:` comments where helpful
+
+3. **Review during generation** — After every 5-10 cells, briefly verify the notebook is building correctly. Read it back if needed.
+
+### Phase 4: Validation
+
+1. **Read notebook back** — Use the Read tool to read the entire `.ipynb` file. Verify:
+   - Total cell count matches outline
+   - Cell order is correct
+   - No missing sections
+2. **Verify code quality** — Check all code cells for:
+   - Correct FiftyOne import aliases (`fo`, `foz`, `fob`, `fot`, `F`)
+   - No deprecated APIs
+   - Consistent variable names throughout
+   - `dataset` variable used consistently
+   - Field names match between inference, evaluation, and filtering cells
+3. **Verify narrative flow** — Check markdown cells for:
+   - Logical progression from section to section
+   - No jargon without explanation (for getting-started)
+   - Each markdown cell explains the **why**, not just the **what**
+4. **Execute the notebook** — Create an isolated virtual environment and run end-to-end with `papermill` to avoid modifying the user's system Python:
+   ```bash
+   python -m venv .notebook-test-env
+   .notebook-test-env/bin/pip install -q papermill ipykernel anywidget
+   .notebook-test-env/bin/python -m ipykernel install --user --name python3 --display-name "Python 3"
+   .notebook-test-env/bin/papermill notebook.ipynb notebook_output.ipynb
+   ```
+   Fix any runtime errors, then re-run until all cells pass. Clean up after: `rm -rf .notebook-test-env`. Common issues:
+   - `session.view` requires a `DatasetView`, not a `Dataset` — use `dataset.view()`
+   - Missing packages — add them to the notebook's install cell
+   - Plotly widgets need `anywidget` in headless environments
+5. **Present summary** — Tell the user:
+   - Notebook path
+   - Total cells (N markdown + N code)
+   - Sections covered
+   - Execution status (all cells passed / errors fixed)
+   - How to run it (e.g., `jupyter notebook path/to/notebook.ipynb`)
+
+## Notebook Structure Reference
+
+See [NOTEBOOK-STRUCTURE.md](NOTEBOOK-STRUCTURE.md) for detailed cell structure patterns for each pipeline stage, including cell shapes and markdown patterns.
+
+### Code Pattern Sources
+
+For actual code patterns, fetch `https://docs.voxel51.com/llms.txt` as the authoritative source. Related skills provide additional context for specific pipeline stages:
+
+| Pipeline Stage | Related Skill |
+|---|---|
+| Imports & conventions | [fiftyone-code-style](../fiftyone-code-style/SKILL.md) |
+| Data loading | [fiftyone-dataset-import](../fiftyone-dataset-import/SKILL.md) |
+| Inference | [fiftyone-dataset-inference](../fiftyone-dataset-inference/SKILL.md) |
+| Evaluation | [fiftyone-model-evaluation](../fiftyone-model-evaluation/SKILL.md) |
+| Export | [fiftyone-dataset-export](../fiftyone-dataset-export/SKILL.md) |
+| Embeddings & visualization | [fiftyone-embeddings-visualization](../fiftyone-embeddings-visualization/SKILL.md) |
+| Duplicates | [fiftyone-find-duplicates](../fiftyone-find-duplicates/SKILL.md) |
+
+## Common Use Cases
+
+### Use Case 1: Getting Started with Object Detection
+
+**User says:** "Create a getting-started notebook for object detection"
+
+**Notebook outline (21 cells):**
+
+| Cell | Type | Content |
+|---|---|---|
+| 0 | markdown | `# Getting Started with Object Detection in FiftyOne` |
+| 1 | markdown | What You Will Learn (bullet list) |
+| 2 | code | `!pip install fiftyone ultralytics` |
+| 3 | markdown | ## Setup |
+| 4 | code | Imports (`fo`, `foz`, `F`) |
+| 5 | markdown | ## Load Dataset |
+| 6 | code | `dataset = foz.load_zoo_dataset(...)` + `print(dataset)` + `print(dataset.first())` |
+| 7 | markdown | ## Explore in the FiftyOne App |
+| 8 | code | `session = fo.launch_app(dataset)` |
+| 9 | markdown | ## Understand the Data |
+| 10 | code | `dataset.count_values("ground_truth.detections.label")` |
+| 11 | markdown | ## Run Model Inference |
+| 12 | code | `model = foz.load_zoo_model(...)` + `dataset.apply_model(...)` + `session.view = dataset.view()` |
+| 13 | markdown | ## Evaluate Predictions |
+| 14 | code | `dataset.evaluate_detections(...)` + `results.print_report()` |
+| 15 | markdown | ## Analyze Errors |
+| 16 | code | Evaluation patches: `dataset.to_evaluation_patches("eval")`, filter to FP |
+| 17 | markdown | ## Export for Training |
+| 18 | code | `dataset.export(...)` to YOLOv5 format |
+| 19 | markdown | ## Conclusion + Next Steps |
+| 20 | code | Cleanup: `fo.delete_dataset(...)` |
+
+### Use Case 2: Tutorial - Finding Annotation Mistakes
+
+**User says:** "Write a tutorial on finding annotation mistakes with FiftyOne"
+
+**Notebook outline (29 cells):**
+
+| Phase | Cells | Content |
+|---|---|---|
+| Introduction | 0-2 | Title, problem statement (why annotation quality matters), learning goals |
+| Setup | 3-4 | pip install, imports |
+| Data | 5-8 | Load detection dataset, inspect schema, explore class distribution, launch App |
+| Concept | 9-10 | Explain mistakenness: what it is, how it works, why embeddings help |
+| Compute | 11-14 | Compute embeddings, compute mistakenness, view mistakenness distribution |
+| Explore | 15-18 | Sort by mistakenness, view worst samples in App, tag suspicious annotations |
+| Hardness | 19-22 | Compute hardness, compare with mistakenness, find ambiguous samples |
+| Action | 23-25 | Filter to flagged samples, export for re-annotation |
+| Conclusion | 26-28 | Summary, key takeaways, next steps, cleanup |
+
+### Use Case 3: Recipe - Export to COCO Format
+
+**User says:** "Quick recipe to export my dataset to COCO format"
+
+**Notebook outline (7 cells):**
+
+| Cell | Type | Content |
+|---|---|---|
+| 0 | markdown | `# Export a FiftyOne Dataset to COCO Format` + one sentence description |
+| 1 | code | `import fiftyone as fo` + `import fiftyone.types as fot` |
+| 2 | code | `dataset = fo.load_dataset("my-dataset")` |
+| 3 | markdown | Brief explanation of COCO format |
+| 4 | code | `dataset.export(export_dir="/tmp/coco-export", dataset_type=fot.COCODetectionDataset, label_field="ground_truth")` |
+| 5 | code | Verify: `!ls /tmp/coco-export/` |
+| 6 | markdown | Variations: export with filters, export labels only, export to YOLOv5 |
+
+### Use Case 4: Full ML Pipeline
+
+**User says:** "Create a complete ML pipeline notebook"
+
+**Notebook outline (31 cells):**
+
+| Phase | Cells | Content |
+|---|---|---|
+| Title | 0-1 | Title + learning goals |
+| Setup | 2-3 | pip install + imports |
+| Load | 4-6 | Load dataset, inspect, print schema |
+| Explore | 7-10 | Launch App, class distribution, sample statistics, filtering |
+| Deduplicate | 11-13 | Compute embeddings, find near-duplicates, remove duplicates |
+| Infer | 14-16 | Load model, apply to dataset, view predictions in App |
+| Evaluate | 17-21 | Run evaluation, print report, confusion matrix, PR curves, patches |
+| Visualize | 22-24 | Compute UMAP visualization, explore embedding space, find clusters |
+| Export | 25-27 | Export curated dataset, export to training format |
+| Conclusion | 28-30 | Summary, next steps, cleanup |
+
+## Troubleshooting
+
+**Error: "Cells appear in wrong order"**
+- Cause: Inserting cells without `cell_id` — each insert without `cell_id` goes to the **beginning** of the notebook, resulting in reversed order
+- Solution: Use `cell_id` chaining (see Directive 4). Insert first cell without `cell_id`, read notebook to get its ID, then chain each subsequent cell after the previous one. Use `edit_mode: "replace"` to fix individual cells.
+
+**Error: "Empty notebook after generation"**
+- Cause: Write tool did not create valid JSON structure
+- Solution: Verify the minimal `.ipynb` JSON includes `"cells": []` and `"nbformat": 4`
+
+**Error: "Import errors in generated code"**
+- Cause: Using deprecated or incorrect FiftyOne APIs
+- Solution: Fetch `https://docs.voxel51.com/llms.txt` before generating code. Use standard aliases: `fo`, `foz`, `fob`, `fot`, `F`. Check that pip install cell includes all required packages.
+
+**Error: "Generated code uses deprecated APIs"**
+- Cause: Stale API patterns
+- Solution: Fetch `https://docs.voxel51.com/llms.txt` for current API. Common deprecation: `dataset.count("field")` → `dataset.count_values("field")`
+
+**Error: "Notebook doesn't render in Jupyter"**
+- Cause: Invalid `.ipynb` JSON structure
+- Solution: Verify `"nbformat": 4` is set and `"cells"` is an array, not null
+
+## Best Practices
+
+1. **Keep code cells short** - Under 15 lines, one concept per cell
+2. **Use markdown liberally** - Every code cell should have a markdown cell explaining it
+3. **Show output** - Use `print()` and display so users see intermediate results
+4. **Include App visualization** - At least one `fo.launch_app()` call per notebook
+5. **Use zoo datasets for demos** - Makes notebooks immediately runnable
+6. **Include cleanup** - Add a cleanup cell at the end to delete temporary datasets
+7. **Link to docs** - Include links to relevant FiftyOne documentation
+8. **Progressive complexity** - Start simple, build to complex
+9. **Explain the "why"** - Don't just show code; explain why each step matters
+10. **Test your outline first** - Get user approval on the structure before generating 30+ cells
+
+## Resources
+
+- [FiftyOne Documentation](https://docs.voxel51.com)
+- [FiftyOne LLM Docs](https://docs.voxel51.com/llms.txt) - Fetch for comprehensive API reference
+- [FiftyOne Tutorials](https://docs.voxel51.com/tutorials/index.html)
+- [FiftyOne Recipes](https://docs.voxel51.com/recipes/index.html)
+- [FiftyOne Model Zoo](https://docs.voxel51.com/model_zoo/index.html)
+- [FiftyOne User Guide](https://docs.voxel51.com/user_guide/index.html)

--- a/skills/fiftyone-create-notebook/TUTORIAL-TEMPLATES.md
+++ b/skills/fiftyone-create-notebook/TUTORIAL-TEMPLATES.md
@@ -1,0 +1,441 @@
+# Tutorial Templates
+
+## Contents
+- [Canonical Structure](#canonical-structure)
+- [Key Differences from Getting Started](#key-differences-from-getting-started)
+- [Template: Evaluating Object Detection Models](#template-evaluating-object-detection-models)
+- [Template: Clustering Images with Embeddings](#template-clustering-images-with-embeddings)
+- [Template: Finding and Fixing Annotation Mistakes](#template-finding-and-fixing-annotation-mistakes)
+- [Adaptation Guidelines](#adaptation-guidelines)
+
+---
+
+**Target audience:** Intermediate users who know FiftyOne basics
+**Duration:** 20-45 minutes
+**Cell count:** 20-35 cells
+**Scope:** Deep dive into a specific FiftyOne capability
+
+The templates below are **structural examples** — follow the canonical structure and cell patterns, but adapt the dataset, model, field names, and sections to the user's specific topic. Fetch `https://docs.voxel51.com/llms.txt` for the correct API for any topic.
+
+## Canonical Structure
+
+| Phase | Cells | Content |
+|---|---|---|
+| Introduction | 0-2 | Title + problem statement (real-world motivation) + learning goals |
+| Setup | 3-5 | pip install (may need extra packages) + imports + environment check |
+| Data | 6-9 | Load dataset + inspect schema + explore specific aspects + App |
+| Concept | 10-12 | Explain the capability being demonstrated (theory, intuition, analogies) |
+| Application | 13-20 | Apply step-by-step + show intermediate results + explore in App |
+| Analysis | 21-25 | Analyze results + create visualizations + draw insights |
+| Variation | 26-28 | Alternative approach or parameter tuning |
+| Action | 29-31 | Take action on findings (tag, export, filter, curate) |
+| Conclusion | 32-34 | Summary + key takeaways + next steps + links |
+
+## Key Differences from Getting Started
+
+- **Problem-driven:** Start with a real-world problem, not just "how to use X"
+- **Deeper explanations:** Include theory and intuition, not just code
+- **Multiple approaches:** Show variations and parameter tuning
+- **Interpretation:** Explain what results mean, not just how to compute them
+- **Action-oriented:** End with actionable next steps based on findings
+
+## Template: Evaluating Object Detection Models
+
+### Cell 0 — markdown
+```markdown
+# Evaluating Object Detection Models in FiftyOne
+
+How good is your object detection model, really? Aggregate metrics like mAP
+tell part of the story, but understanding *where* and *why* your model fails
+is what drives real improvements.
+
+In this tutorial, you will go beyond mAP to perform a thorough error analysis
+using FiftyOne's evaluation framework, including per-class breakdowns,
+confusion matrices, precision-recall curves, and evaluation patches that show
+you every true positive, false positive, and false negative.
+```
+
+### Cell 1 — markdown
+```markdown
+## What You Will Learn
+
+- Run COCO-style object detection evaluation
+- Interpret mAP, per-class precision, and recall
+- Visualize confusion matrices and precision-recall curves
+- Use evaluation patches to examine individual TP/FP/FN predictions
+- Compare model performance across different IoU thresholds
+- Identify systematic failure patterns
+```
+
+### Cell 2 — code
+```python
+!pip install -q fiftyone ultralytics
+```
+
+### Cell 3 — markdown
+```markdown
+## Setup
+```
+
+### Cell 4 — code
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+from fiftyone import ViewField as F
+```
+
+### Cell 5 — markdown
+```markdown
+## Load Dataset and Run Inference
+
+We will use a subset of COCO 2017 validation with ground truth annotations,
+then run YOLOv8 to generate predictions we can evaluate.
+```
+
+### Cell 6 — code
+```python
+dataset = foz.load_zoo_dataset(
+    "coco-2017",
+    split="validation",
+    max_samples=500,
+    seed=51,
+    dataset_name="eval-tutorial",
+)
+
+model = foz.load_zoo_model("yolov8m-coco-torch")
+dataset.apply_model(model, label_field="predictions")
+
+print(dataset)
+```
+
+### Cell 7 — markdown
+```markdown
+## Explore the Data
+
+Before diving into evaluation metrics, browse the dataset in the App to see
+both ground truth annotations and model predictions side by side.
+```
+
+### Cell 8 — code
+```python
+session = fo.launch_app(dataset)
+```
+
+### Cell 9 — markdown
+```markdown
+## Understanding COCO Evaluation
+
+COCO-style evaluation matches predictions to ground truth annotations using
+Intersection over Union (IoU). A prediction is a **true positive** if its IoU
+with a ground truth box exceeds a threshold (default 0.50) and the class matches.
+Unmatched predictions are **false positives**, and unmatched ground truth boxes
+are **false negatives**.
+
+**mAP** (mean Average Precision) averages the area under the precision-recall
+curve across all classes, giving a single number that summarizes detection quality.
+```
+
+### Cell 10 — markdown
+```markdown
+## Run Evaluation
+```
+
+### Cell 11 — code
+```python
+results = dataset.evaluate_detections(
+    "predictions",
+    gt_field="ground_truth",
+    eval_key="eval",
+    method="coco",
+    compute_mAP=True,
+)
+
+results.print_report(classes=["person", "car", "dog", "cat", "truck", "chair"])
+print(f"\nmAP: {results.mAP():.3f}")
+print(f"mAR: {results.mAR():.3f}")
+```
+
+### Cell 12 — markdown
+```markdown
+## Confusion Matrix
+
+The confusion matrix shows how classes get confused with each other. Large
+off-diagonal values indicate classes the model frequently mixes up.
+```
+
+### Cell 13 — code
+```python
+plot = results.plot_confusion_matrix(
+    classes=["person", "car", "dog", "cat", "truck", "bus", "chair"],
+)
+plot.show()
+```
+
+### Cell 14 — markdown
+```markdown
+## Precision-Recall Curves
+
+Precision-recall curves show the tradeoff between precision (how many
+predictions are correct) and recall (how many ground truth objects are found)
+at different confidence thresholds.
+```
+
+### Cell 15 — code
+```python
+plot = results.plot_pr_curves(classes=["person", "car", "dog", "cat"])
+plot.show()
+```
+
+### Cell 16 — markdown
+```markdown
+## Evaluation Patches: Examining Individual Predictions
+
+Evaluation patches transform your dataset into a view where each row is a
+single prediction or ground truth annotation, labeled as TP, FP, or FN.
+This is the most powerful tool for understanding model errors.
+```
+
+### Cell 17 — code
+```python
+patches = dataset.to_evaluation_patches("eval")
+
+print("Evaluation patch counts:")
+print(patches.count_values("type"))
+
+# Examine false positives — predictions with no matching ground truth
+fp_view = patches.match(F("type") == "fp")
+session.view = fp_view
+```
+
+### Cell 18 — markdown
+```markdown
+### Examining False Negatives
+
+False negatives are ground truth objects the model failed to detect. These
+often reveal small, occluded, or unusual-looking objects that the model
+struggles with.
+```
+
+### Cell 19 — code
+```python
+# Examine false negatives — ground truth objects the model missed
+fn_view = patches.match(F("type") == "fn")
+session.view = fn_view
+```
+
+### Cell 20 — markdown
+```markdown
+## High-Error Samples
+
+Some images have more errors than others. Sorting by false positive count
+reveals where the model struggles most.
+```
+
+### Cell 21 — code
+```python
+# Samples with the most false positives
+high_fp = dataset.sort_by("eval_fp", reverse=True)
+session.view = high_fp[:20]
+
+print("Samples with most false positives:")
+for sample in high_fp[:5]:
+    print(f"  {sample.filepath}: {sample.eval_fp} FP, {sample.eval_fn} FN")
+```
+
+### Cell 22 — markdown
+```markdown
+## Varying IoU Threshold
+
+IoU threshold affects what counts as a "match." A stricter threshold (0.75)
+penalizes poorly localized detections, while a lenient threshold (0.25)
+focuses on whether the model found the object at all.
+```
+
+### Cell 23 — code
+```python
+# Strict evaluation at IoU 0.75
+results_strict = dataset.evaluate_detections(
+    "predictions",
+    gt_field="ground_truth",
+    eval_key="eval_strict",
+    method="coco",
+    iou=0.75,
+    compute_mAP=True,
+)
+print(f"mAP @ IoU=0.75: {results_strict.mAP():.3f}")
+print(f"mAP @ IoU=0.50: {results.mAP():.3f}")
+```
+
+### Cell 24 — markdown
+```markdown
+## Per-Class Analysis
+
+Looking at per-class performance reveals which object categories the model
+handles well and which need improvement.
+```
+
+### Cell 25 — code
+```python
+# Filter to a specific class to analyze its errors
+person_fp = patches.match(
+    (F("type") == "fp") & (F("predictions.detections.label") == "person")
+)
+print(f"Person false positives: {len(person_fp)}")
+session.view = person_fp
+```
+
+### Cell 26 — markdown
+```markdown
+## Tag Problematic Samples
+
+Tag samples with high error rates for further review or re-annotation.
+```
+
+### Cell 27 — code
+```python
+# Tag samples with more than 5 false positives
+high_error = dataset.match(F("eval_fp") > 5)
+high_error.tag_samples("needs-review")
+print(f"Tagged {len(high_error)} samples for review")
+```
+
+### Cell 28 — markdown
+```markdown
+## Conclusion
+
+In this tutorial, you learned how to:
+
+- **Run COCO evaluation** with `evaluate_detections()` to compute mAP and per-class metrics
+- **Visualize** confusion matrices and precision-recall curves
+- **Examine individual errors** using evaluation patches (TP/FP/FN)
+- **Compare IoU thresholds** to understand localization quality
+- **Identify failure patterns** by sorting by error counts and filtering by class
+- **Tag** problematic samples for review
+
+**Key Takeaways:**
+- mAP alone does not tell the full story — always examine patches
+- False positives and false negatives have different causes and solutions
+- Per-class analysis reveals which categories need more training data
+
+**Next Steps:**
+- [Finding Annotation Mistakes](https://docs.voxel51.com/tutorials/detection_mistakes.html)
+- [Evaluation Guide](https://docs.voxel51.com/user_guide/evaluation.html)
+- [Model Zoo](https://docs.voxel51.com/model_zoo/index.html)
+```
+
+### Cell 29 — code
+```python
+# Cleanup
+fo.delete_dataset("eval-tutorial")
+```
+
+---
+
+## Template: Clustering Images with Embeddings
+
+### Cell 0 — markdown
+```markdown
+# Clustering Images with Embeddings in FiftyOne
+
+When working with large image datasets, understanding the visual structure
+of your data is crucial. Are there natural groups? Are some images redundant?
+Are there outliers that do not belong?
+
+In this tutorial, you will use image embeddings and dimensionality reduction
+to visualize your dataset in 2D, discover clusters, and identify interesting
+subsets for further analysis.
+```
+
+| Cell | Type | Content |
+|---|---|---|
+| 0 | markdown | Title + problem statement (shown above) |
+| 1 | markdown | What You Will Learn: compute CLIP embeddings, UMAP visualization, explore clusters, find outliers |
+| 2 | code | `!pip install -q fiftyone umap-learn` |
+| 3 | markdown | `## Setup` + import explanation |
+| 4 | code | Imports: `fo`, `foz`, `fob`, `F` |
+| 5 | markdown | `## Load the Dataset` + explain quickstart dataset |
+| 6 | code | `foz.load_zoo_dataset("quickstart", dataset_name="clustering-tutorial")` + `print(dataset)` |
+| 7 | markdown | `## Explore in the FiftyOne App` |
+| 8 | code | `session = fo.launch_app(dataset)` |
+| 9 | markdown | `## What Are Embeddings?` + explain how embeddings capture visual similarity |
+| 10 | markdown | `## Dimensionality Reduction` + explain UMAP/t-SNE, why 2D helps humans |
+| 11 | markdown | `## Compute Embeddings and Visualization` + explain CLIP model choice |
+| 12 | code | `fob.compute_similarity(...)` + `fob.compute_visualization(...)` + `session.view = dataset.view()` |
+| 13 | markdown | `## Explore the Embedding Space` + how to use Embeddings panel, color by labels |
+| 14 | code | Examine clusters by coloring, lasso selection |
+| 15 | markdown | Interpret cluster patterns: what groupings reveal about the data |
+| 16 | code | Select and examine specific cluster subsets |
+| 17 | markdown | `## Find Outliers with Uniqueness` + explain uniqueness scoring |
+| 18 | code | `fob.compute_uniqueness(...)` + sort by uniqueness descending + `session.view` |
+| 19 | markdown | `## Examine Redundant Images` + least unique = most redundant |
+| 20 | code | Sort by uniqueness ascending + `session.view` |
+| 21 | markdown | `## Alternative: t-SNE Visualization` + compare UMAP vs t-SNE tradeoffs |
+| 22 | code | `fob.compute_visualization(dataset, brain_key="clip_tsne", method="tsne")` |
+| 23 | markdown | `## Tag Interesting Subsets` |
+| 24 | code | Tag outliers or clusters for review |
+| 25 | markdown | `## Export for Further Analysis` |
+| 26 | code | Export tagged subset |
+| 27 | markdown | `## Conclusion` + summary + key takeaways + next steps links |
+| 28 | code | Cleanup: `fo.delete_dataset("clustering-tutorial")` |
+
+---
+
+## Template: Finding and Fixing Annotation Mistakes
+
+### Cell 0 — markdown
+```markdown
+# Finding and Fixing Annotation Mistakes with FiftyOne
+
+Annotation quality directly impacts model performance. Even professional
+annotators make mistakes — missing objects, wrong labels, imprecise bounding
+boxes. Finding these errors manually in large datasets is impractical.
+
+In this tutorial, you will use FiftyOne's brain methods to automatically
+surface likely annotation mistakes, rank them by severity, and take
+corrective action.
+```
+
+| Cell | Type | Content |
+|---|---|---|
+| 0 | markdown | Title + problem statement (shown above) |
+| 1 | markdown | What You Will Learn: compute mistakenness, hardness, find annotation errors, tag for re-annotation |
+| 2 | code | `!pip install -q fiftyone ultralytics` |
+| 3 | markdown | `## Setup` + import explanation |
+| 4 | code | Imports: `fo`, `foz`, `fob`, `F` |
+| 5 | markdown | `## Load Dataset and Run Inference` + explain dataset choice, why inference is needed |
+| 6 | code | Load detection dataset + apply model + `print(dataset)` |
+| 7 | markdown | `## Explore in the FiftyOne App` |
+| 8 | code | `session = fo.launch_app(dataset)` |
+| 9 | markdown | `## What Is Mistakenness?` + explain concept: model disagreement reveals annotation errors |
+| 10 | markdown | How mistakenness scoring works: comparing confident predictions to annotations |
+| 11 | markdown | `## Compute Mistakenness` |
+| 12 | code | `fob.compute_mistakenness(...)` + sort by mistakenness + `session.view` |
+| 13 | markdown | `## Examine Most Likely Mistakes` |
+| 14 | code | View top 20 in App, print mistakenness distribution |
+| 15 | markdown | Interpret patterns: missing annotations, wrong labels, imprecise boxes |
+| 16 | code | Filter to specific error patterns |
+| 17 | markdown | `## Compute Hardness` + explain hardness: model uncertainty = ambiguous examples |
+| 18 | code | `fob.compute_hardness(...)` + sort by hardness + `session.view` |
+| 19 | markdown | `## Cross-Reference Mistakenness and Hardness` + why both together is powerful |
+| 20 | code | Filter samples high in both mistakenness and hardness |
+| 21 | markdown | Interpret: these samples are most valuable for review |
+| 22 | code | View cross-referenced samples in App |
+| 23 | markdown | `## Tag for Re-Annotation` |
+| 24 | code | Tag likely mistakes + `print()` count |
+| 25 | markdown | `## Export Flagged Samples` |
+| 26 | code | Export tagged samples for review |
+| 27 | markdown | `## Conclusion` + summary + key takeaways + next steps links |
+| 28 | code | Cleanup: `fo.delete_dataset(...)` |
+
+## Adaptation Guidelines
+
+When creating a new tutorial for a topic not listed above:
+
+1. **Start with a real-world problem** — "Why would someone need this?"
+2. **Load an appropriate dataset** — Pick one that demonstrates the concept well
+3. **Explain concepts before code** — 2-3 markdown cells of intuition before applying
+4. **Show intermediate results** — Print counts, show distributions, update the App view
+5. **Include a variation section** — Try different parameters or an alternative approach
+6. **End with action** — Don't just analyze; do something with the results (tag, export, filter)
+7. **Keep it under 35 cells** — Focus depth over breadth
+8. **Include interpretation** — "The results show that..." not just "The output is..."


### PR DESCRIPTION
## Summary
- Add `fiftyone-create-notebook` skill that generates Jupyter notebooks for FiftyOne workflows
- Supports 4 notebook types: getting-started guides, tutorials, recipes, and full ML pipelines
- Includes 5 reference files: SKILL.md, NOTEBOOK-STRUCTURE.md, and 3 template docs (getting-started, tutorial, recipe)

## Test
Tutorial support functionally validated by generating and executing a 31-cell detection evaluation tutorial end-to-end
