### PR TITLE
Add Cursor plugin config and fix frontmatter

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "fiftyone-skills",
+  "owner": {
+    "name": "Voxel51"
+  },
+  "metadata": {
+    "description": "Agent Context Protocol (ACP) skills for computer vision workflows using FiftyOne.",
+    "version": "1.0.3"
+  },
+  "plugins": [
+    {
+      "name": "fiftyone-skills",
+      "source": ".",
+      "skills": "skills",
+      "description": "Agent Context Protocol (ACP) skills for computer vision workflows using FiftyOne."
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "fiftyone-skills",
+  "skills": "skills",
+  "mcpServers": ".mcp.json",
+  "description": "Agent Context Protocol (ACP) skills for computer vision workflows using FiftyOne.",
+  "version": "1.0.3",
+  "author": {
+    "name": "Voxel51"
+  },
+  "homepage": "https://docs.voxel51.com/",
+  "repository": "https://github.com/voxel51/fiftyone-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "fiftyone",
+    "computer-vision",
+    "machine-learning",
+    "datasets",
+    "model-evaluation"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,13 @@ Thumbs.db
 # Logs
 *.log
 
+# Validation scripts (local-only, from cursor/plugin-template)
+scripts/
+
+# Notebook test outputs
+*_output.ipynb
+.notebook-test-env/
+
 # Agents
 .cursor
 .claude

--- a/commands/help.md
+++ b/commands/help.md
@@ -1,4 +1,5 @@
 ---
+name: help
 description: Get help with FiftyOne skills, understand available workflows, and troubleshoot setup issues
 ---
 

--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -1,4 +1,5 @@
 ---
+name: quickstart
 description: Guided quickstart for FiftyOne - choose between user workflows (import, inference, visualization) or developer workflows (plugin development)
 ---
 


### PR DESCRIPTION
## Summary
- Add `.cursor-plugin/` directory with `plugin.json` and `marketplace.json` for Cursor plugin publishing
- Fix missing `name` field in `commands/help.md` and `commands/quickstart.md` frontmatter (required by Cursor validation)
- Add `scripts/`, `*_output.ipynb`, and `.notebook-test-env/` to `.gitignore`