### PR TITLE
Add dataset curation skill for FiftyOne workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,6 +45,12 @@
       "description": "Visualize datasets in 2D using embeddings with UMAP or t-SNE dimensionality reduction. Use when users want to explore dataset structure, find clusters in images, identify outliers, color samples by class or metadata, or understand data distribution."
     },
     {
+      "name": "fiftyone-dataset-curation",
+      "source": "./skills/fiftyone-dataset-curation",
+      "skills": "./",
+      "description": "End-to-end dataset curation for any FiftyOne dataset: inspect schema and media quality (blur, brightness, corruption, resolution), audit annotation quality (mistakenness, hardness, duplicate labels, IoU overlaps), analyze class distributions and imbalances, explore embedding space and data gaps, find near/exact duplicates, create curated subsets using semantic search and brain ops, build train/val/test splits, and answer natural language questions about your data. Delegates to fiftyone-find-duplicates and fiftyone-embeddings-visualization. Requires FiftyOne MCP server with @voxel51/brain and @voxel51/utils plugins."
+    },
+    {
       "name": "fiftyone-develop-plugin",
       "source": "./skills/fiftyone-develop-plugin",
       "skills": "./",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,40 @@ This repository contains skills for computer vision workflows using FiftyOne and
 - `TUTORIAL-TEMPLATES.md` - Intermediate deep-dive templates
 - `RECIPE-TEMPLATES.md` - Quick practical recipe templates
 
+### FiftyOne Dataset Curation (`fiftyone-dataset-curation/`)
+
+**When to use:** User wants to curate a dataset, check data quality, audit annotations, analyze class distributions, explore the embedding space, find duplicates, create curated subsets, build train/val/test splits, or ask natural language questions about a dataset.
+
+**Instructions:** Load the skill file at `skills/fiftyone-dataset-curation/SKILL.md`
+
+**Key requirements:**
+- FiftyOne MCP server must be running
+- `@voxel51/brain` plugin for brain operations
+- `@voxel51/utils` plugin for metadata and quality ops
+- `@voxel51/evaluation` plugin for annotation audit (mistakenness)
+- FiftyOne App must be launched before brain operators
+
+**Workflow summary (8 phases, any can be run individually):**
+1. Dataset loading (optional — delegates to fiftyone-dataset-import)
+2. Dataset inspection (schema, fields, counts)
+3. Data quality audit (metadata, corruption, resolution, aspect ratio)
+4. Near-duplicate detection (delegates to fiftyone-find-duplicates)
+5. Class distribution and imbalance analysis
+6. Embedding exploration and gap detection (delegates to fiftyone-embeddings-visualization)
+7. Annotation audit (mistakenness, hardness, IoU dedup)
+8. Curated subset creation and train/val/test splits
+
+**Reference files:**
+- `QUALITY-CHECKS.md` - Image quality filtering details
+- `ANNOTATION-AUDIT.md` - Annotation error detection
+- `SUBSET-CREATION.md` - Subset and split workflows
+
+**Related skills:**
+- `fiftyone-dataset-import` (Phase 0 data loading)
+- `fiftyone-find-duplicates` (Phase 3 deduplication)
+- `fiftyone-embeddings-visualization` (Phase 5 exploration)
+- `fiftyone-dataset-inference` (required prereq for Phase 6 annotation audit)
+
 ### FiftyOne Troubleshoot (`fiftyone-troubleshoot/`)
 
 **When to use:** User encounters a recurring FiftyOne problem: dataset disappeared, App won't open, changes not saving, MongoDB errors, video codec failures, notebook connectivity issues, missing plugins, or any common pain point.

--- a/skills/fiftyone-dataset-curation/ANNOTATION-AUDIT.md
+++ b/skills/fiftyone-dataset-curation/ANNOTATION-AUDIT.md
@@ -1,0 +1,301 @@
+# Annotation Audit
+
+Deep-dive annotation quality workflow for FiftyOne datasets. All field references are discovered dynamically — never hardcoded.
+
+---
+
+## Prerequisites Check
+
+Before running any annotation audit step:
+
+```
+dataset_summary()
+get_field_schema(flat=True)
+```
+
+From the schema, identify:
+1. **Ground truth field** — typically a Detections, Classifications, Keypoints, or Segmentation field
+2. **Predictions field** — must exist for mistakenness computation
+
+If no predictions field exists:
+> "Annotation audit requires a predictions field. Use the `fiftyone-dataset-inference` skill to generate predictions, then return here."
+
+Do not proceed with mistakenness if predictions are absent.
+
+---
+
+## 1. Mistakenness Detection
+
+**Operator:** `@voxel51/brain/compute_mistakenness`
+
+### What it does
+
+- **Classification**: Adds a `mistakenness` float field per sample (0 = likely correct, 1 = likely wrong)
+- **Detection**: Adds:
+  - `mistakenness` — overall sample mistakenness score
+  - `mistakenness_loc` — localization error (bbox placement is wrong but class may be right)
+  - `possible_spurious` — predictions present but no matching GT (possible extra annotations)
+  - `possible_missing` — GT present but high-confidence predictions with no GT match (likely missing annotations)
+
+### Step 1: Discover and run operator
+
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/compute_mistakenness")
+execute_operator(
+    operator_uri="@voxel51/brain/compute_mistakenness",
+    params={
+        "pred_field": "<predictions_field>",    # from schema discovery
+        "label_field": "<ground_truth_field>",  # from schema discovery
+        "mistakenness_field": "mistakenness"
+    }
+)
+```
+
+Confirm field names with the user before running. This operation writes new fields and cannot be trivially undone.
+
+### Step 2: Review top offenders
+
+```
+set_view(sort_by="mistakenness", reverse=True, limit=50)
+```
+
+Direct user to the FiftyOne App (use get_session_info() to get the URL) to review samples side-by-side (predictions vs. ground truth).
+
+### Step 3: Tag for review (after user confirmation)
+
+```
+tag_samples(["annotation_review"])
+```
+
+Ask the user how many top-mistakenness samples to tag before executing.
+
+---
+
+## 2. Hardness Analysis
+
+**Operator:** `@voxel51/brain/compute_hardness`
+
+**Prerequisite:** Predictions field must include logits (softmax probabilities), not just hard labels.
+
+### What it does
+
+Adds a `hardness` float field per sample:
+- High hardness = ambiguous, edge-case samples (model is uncertain)
+- Low hardness = easy, clearly-classifiable samples
+
+Hard samples are NOT errors — they are valuable for training (teach the model edge cases).
+
+### Run operator
+
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/compute_hardness")
+execute_operator(
+    operator_uri="@voxel51/brain/compute_hardness",
+    params={
+        "pred_field": "<predictions_field>",    # from schema discovery
+        "hardness_field": "hardness"
+    }
+)
+```
+
+### Review hard samples
+
+```
+set_view(sort_by="hardness", reverse=True, limit=50)
+```
+
+Use cases:
+- Tag hard samples for active learning prioritization: `tag_samples(["hard"])`
+- Include hard samples in test set to better measure model performance
+
+---
+
+## 3. IoU Duplicate Object Detection (Detection Datasets Only)
+
+**Operator:** `@voxel51/utils/compute_max_ious`
+
+Use for detecting duplicate or heavily overlapping annotations in the same image.
+
+### What it does
+
+Adds a `max_iou` attribute to each detection in the specified field. High IoU (> 0.75) between two annotations in the same image typically indicates duplicate annotations.
+
+### Run operator
+
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/utils/compute_max_ious")
+execute_operator(
+    operator_uri="@voxel51/utils/compute_max_ious",
+    params={"field": "<detections_field>"}   # from schema discovery
+)
+```
+
+### Filter for overlapping annotations
+
+```
+set_view(filters={"<detections_field>.detections.max_iou": {"$gt": 0.75}})
+```
+
+Adapt the filter path from the detections field name discovered in schema.
+
+### Review in App
+
+Direct user to the FiftyOne App (use get_session_info() to get the URL) to visually confirm duplicates. Offer to tag affected samples:
+```
+tag_samples(["duplicate_annotations"])
+```
+
+---
+
+## 4. Possible Missing Annotations
+
+After running `compute_mistakenness` on a detection dataset, check for samples with possible missing ground truth annotations:
+
+```
+set_view(filters={"possible_missing": {"$gt": 0}})
+```
+
+These are samples where the model has high-confidence predictions that have no matching ground truth annotation. This often indicates the annotator missed objects.
+
+### Workflow
+
+1. Filter to samples with `possible_missing > 0`
+2. Direct user to the FiftyOne App (use `get_session_info()` to get the URL) to review each sample
+3. For confirmed missing annotations: tag for re-annotation:
+   ```
+   tag_samples(["needs_reannotation"])
+   ```
+4. Export sample IDs and filepaths for re-annotation pipeline
+
+---
+
+## 5. Possible Spurious Annotations
+
+After running `compute_mistakenness`, check for spurious (extra) annotations:
+
+```
+set_view(filters={"possible_spurious": {"$gt": 0}})
+```
+
+These are samples where ground truth annotations exist but the model consistently predicts nothing there. This may indicate:
+- Incorrect class labels in annotations
+- Objects annotated that don't belong to any target class
+- Annotation tool errors
+
+### Workflow
+
+1. Filter to samples with `possible_spurious > 0`
+2. Direct user to the FiftyOne App (use `get_session_info()` to get the URL) for side-by-side review (predictions panel vs. ground truth panel)
+3. Tag after confirmation:
+   ```
+   tag_samples(["spurious_annotations"])
+   ```
+
+---
+
+## 6. Side-by-Side Review Workflow
+
+For all annotation audit results, guide the user through systematic App-based review:
+
+1. **Set the sorted view** (use whichever metric is most relevant):
+   ```
+   set_view(sort_by="mistakenness", reverse=True, limit=100)
+   ```
+
+2. **Enable side-by-side panel** in App:
+   - Open the Fields panel → enable both ground truth and predictions fields
+   - The App will render both label sets simultaneously
+
+3. **Review sample by sample**:
+   - Check label correctness
+   - Check bbox placement (localization)
+   - Check for missing objects
+   - Check for spurious annotations
+
+4. **Tag during review** (confirm count before tagging):
+   ```
+   tag_samples(["annotation_review"])
+   ```
+
+5. **Export reviewed sample IDs** for re-annotation:
+   ```python
+   # Python SDK guidance
+   review_view = dataset.match_tags(["annotation_review"])
+   sample_ids = review_view.values("id")
+   filepaths  = review_view.values("filepath")
+   ```
+
+---
+
+## 7. Annotation Consistency via Embeddings
+
+Use embedding similarity to find visually similar samples with inconsistent annotations.
+
+### Prerequisite
+CLIP or DINOv2 similarity index must exist (from Phase 5 of SKILL.md).
+
+### Workflow
+
+1. Pick a sample with suspicious annotation
+2. Find visually similar samples:
+   ```
+   execute_operator(
+       operator_uri="@voxel51/brain/sort_by_similarity",
+       params={"sample_id": "<suspicious_sample_id>", "k": 10, "brain_key": "<sim_key>"}
+   )
+   ```
+3. Compare annotations across similar images in App
+4. Flag inconsistent samples
+
+This approach surfaces:
+- Same object class annotated differently across similar images
+- Missing annotations on similar scenes
+
+---
+
+## 8. Class-Level Consistency
+
+Use aggregations to identify classes with very few samples that may have inconsistent annotation guidelines:
+
+```
+count_values("<label_field>.label")
+```
+or for detection datasets:
+```
+count_values("<detections_field>.detections.label")
+```
+
+**Flags to report:**
+- Classes with < 20 samples — annotation guidelines may not be well-established
+- Classes where label names are slightly different spellings of the same concept (e.g., `"car"` vs. `"Car"` vs. `"vehicle"`) — use `distinct` to catch these:
+  ```
+  distinct("<detections_field>.detections.label")
+  ```
+
+### Label standardization
+
+If inconsistent label names are found, recommend consolidation:
+```python
+# Python SDK guidance
+# view.map_labels("<detections_field>", {"car": "road_vehicle", "truck": "road_vehicle"})
+# view.save()  # REQUIRED after map_labels — never skip
+```
+
+Always confirm the remapping dict with the user before running. Present all unique labels and ask which should be merged.
+
+---
+
+## Audit Summary Table
+
+| Issue type | MCP tool / operator | Tag suggestion |
+|-----------|--------------------|-|
+| Wrong labels | `compute_mistakenness` → sort mistakenness | `annotation_review` |
+| Bad bbox placement | `compute_mistakenness` → sort mistakenness_loc | `localization_error` |
+| Missing annotations | `possible_missing > 0` filter | `needs_reannotation` |
+| Spurious annotations | `possible_spurious > 0` filter | `spurious_annotations` |
+| Duplicate bboxes | `compute_max_ious` → IoU > 0.75 | `duplicate_annotations` |
+| Hard/ambiguous samples | `compute_hardness` → sort hardness | `hard` |
+| Label inconsistency | `distinct` + `count_values` | manual merge |

--- a/skills/fiftyone-dataset-curation/QUALITY-CHECKS.md
+++ b/skills/fiftyone-dataset-curation/QUALITY-CHECKS.md
@@ -1,0 +1,410 @@
+# Data Quality Checks
+
+Deep-dive quality audit for any FiftyOne dataset. All field references are discovered dynamically — never hardcoded.
+
+---
+
+## Prerequisites
+
+Before running any quality check:
+
+```
+dataset_summary()
+get_field_schema(flat=True)
+```
+
+Confirm media type. Quality checks apply to image datasets directly; for video datasets, checks apply per-frame or per-sample depending on the metric.
+
+---
+
+## 1. Metadata Computation
+
+Compute metadata for all samples. This is required before any resolution, aspect ratio, or file size check.
+
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/utils/compute_metadata")
+execute_operator(operator_uri="@voxel51/utils/compute_metadata", params={})
+```
+
+After completion, verify metadata fields are populated:
+```
+get_field_schema(flat=True)
+bounds("metadata.width")
+```
+
+If `metadata.width` returns null → metadata computation failed. Check that media files are accessible at their `filepath` paths.
+
+---
+
+## 2. Corruption Detection
+
+Samples where metadata computation fails have null metadata — these indicate corrupted or missing files.
+
+```
+set_view(filters={"metadata": null})
+```
+
+Report the count. If any corrupted samples exist:
+1. Show the sample count to the user
+2. Ask for confirmation before tagging
+3. Tag confirmed:
+   ```
+   tag_samples(["corrupted"])
+   ```
+4. Offer to exclude from curation:
+   ```
+   # Python SDK guidance
+   clean_view = dataset.match(F("metadata") != None)
+   ```
+
+---
+
+## 3. Resolution Filtering
+
+### Bounds check
+```
+bounds("metadata.width")
+bounds("metadata.height")
+```
+
+### Distribution
+```
+histogram_values("metadata.width", bins=20)
+histogram_values("metadata.height", bins=20)
+```
+
+### Filtering low-resolution samples
+
+Use ViewField expressions (Python SDK) to build a filtered view:
+```python
+from fiftyone import ViewField as F
+
+min_width  = 224    # adjust to dataset requirements
+min_height = 224
+
+resolution_view = dataset.match(
+    (F("metadata.width") >= min_width) &
+    (F("metadata.height") >= min_height)
+)
+```
+
+Report to user:
+- Total samples
+- Samples below resolution threshold
+- Ask before tagging low-resolution samples as `"low_resolution"`
+
+---
+
+## 4. Aspect Ratio Filtering
+
+Identify panoramic (very wide) and portrait-extreme (very tall) images that may indicate scanning artifacts, incorrect crops, or data pipeline errors.
+
+```python
+from fiftyone import ViewField as F
+
+# Samples wider than 2× their height
+long_filter = F("metadata.width") > 2 * F("metadata.height")
+
+# Samples taller than 2× their width
+tall_filter  = F("metadata.height") > 2 * F("metadata.width")
+
+# Normal aspect ratio
+normal_aspect = (~long_filter) & (~tall_filter)
+
+# Views
+panoramic_view     = dataset.match(long_filter)
+tall_view          = dataset.match(tall_filter)
+normal_aspect_view = dataset.match(normal_aspect)
+```
+
+Report counts for each category. Offer to tag outliers after confirmation:
+```
+tag_samples(["aspect_outlier"])
+```
+
+---
+
+## 5. File Size Filtering
+
+Very small files may be placeholder images, blank frames, or download artifacts.
+
+```
+bounds("metadata.size_bytes")
+mean("metadata.size_bytes")
+std("metadata.size_bytes")
+histogram_values("metadata.size_bytes", bins=20)
+```
+
+Flag samples where `size_bytes` is below a heuristic threshold (e.g., < 5 KB for images expected to be natural scenes). Present to user before tagging.
+
+```python
+from fiftyone import ViewField as F
+tiny_view = dataset.match(F("metadata.size_bytes") < 5000)
+```
+
+---
+
+## 6. Color Channel Check
+
+Grayscale images in RGB datasets can cause silent model errors if not expected.
+
+```python
+from fiftyone import ViewField as F
+
+# Find grayscale samples in an otherwise RGB dataset
+grayscale_view = dataset.match(F("metadata.num_channels") != 3)
+```
+
+Report count and sample IDs. Offer to tag as `"grayscale"` after confirmation.
+
+---
+
+## 7. Comprehensive Image Quality (jacobmarks/image_issues plugin)
+
+The `jacobmarks/image_issues` plugin is the **primary and recommended** method for a full image quality audit. It detects multiple quality dimensions in one pass: blurriness, brightness extremes, contrast issues, entropy, saturation, and aspect ratio anomalies.
+
+**Do NOT use custom cv2 code.** Always use this plugin.
+
+### Step 1: Discover the installed plugin name
+
+Plugin names in documentation may differ from what is actually installed. Always discover dynamically:
+
+```
+list_plugins()
+```
+
+Look for an entry matching "image_issues" or "image-quality". Note the **exact installed name** — use this in all subsequent calls. Common installed names:
+- `@jacobmarks/image_issues` (most common)
+- `image_issues`
+
+### Step 2: Download and enable (if not installed)
+
+If the plugin is not in the `list_plugins()` output:
+```
+download_plugin(plugin_name="jacobmarks/image-quality-issues")
+```
+
+Then confirm the installed name:
+```
+list_plugins()
+enable_plugin(plugin_name="<exact_name_from_list_plugins>")
+```
+
+### Step 3: Discover operator URIs
+
+```
+list_operators(builtin_only=False)
+```
+
+Find operators from the image_issues plugin. Common operators (URIs may vary — use what `list_operators()` returns):
+- `@jacobmarks/image_issues/find_issues` — run all or individual checks
+- `@jacobmarks/image_issues/compute_blurriness`
+- `@jacobmarks/image_issues/compute_brightness`
+- `@jacobmarks/image_issues/compute_contrast`
+- `@jacobmarks/image_issues/compute_entropy`
+- `@jacobmarks/image_issues/compute_saturation`
+- `@jacobmarks/image_issues/compute_aspect_ratio`
+
+**Always confirm URIs from `list_operators()` output. Do not assume from documentation.**
+
+### Step 4: Check delegated service
+
+Brain operators require the delegated service to be running:
+```bash
+fiftyone delegated list
+# If empty or not running:
+fiftyone delegated launch &
+```
+Wait ~5 seconds after starting.
+
+### Step 5: Run quality checks (one issue at a time)
+
+Run each issue check separately with `delegate=True`. Wait for each to complete before starting the next.
+
+```
+# Get operator schema to verify params
+get_operator_schema(operator_uri="@jacobmarks/image_issues/find_issues")
+
+# Run blurriness check
+execute_operator(
+    operator_uri="@jacobmarks/image_issues/find_issues",
+    params={"issue_mode": "SINGLE", "issue": "blurry"},
+    delegate=True
+)
+```
+
+Monitor progress:
+```
+list_delegated_operations()
+```
+
+Wait until status is `"COMPLETED"` before running the next check.
+
+Repeat for each issue type (adjust based on `get_operator_schema()` output):
+```
+{"issue_mode": "SINGLE", "issue": "low_contrast"}
+{"issue_mode": "SINGLE", "issue": "low_saturation"}
+{"issue_mode": "SINGLE", "issue": "weird_aspect_ratio"}
+{"issue_mode": "SINGLE", "issue": "dark"}
+{"issue_mode": "SINGLE", "issue": "bright"}   # See threshold note below
+```
+
+### Step 6: Inspect results
+
+After execution, check what boolean fields were added:
+```
+get_field_schema(flat=True)
+```
+
+The plugin adds per-sample boolean flag fields for each quality dimension (e.g., `blurry: True/False`, `low_contrast: True/False`). Use `count_values` on these fields to understand impact:
+
+```
+count_values("blurry")
+count_values("low_contrast")
+count_values("low_saturation")
+count_values("weird_aspect_ratio")
+```
+
+### Step 7: Create insight views
+
+For each quality flag field discovered via `get_field_schema()`, create a named view. View names are suggestions — adapt to the dataset:
+```python
+# Python SDK guidance — field names come from get_field_schema(), not hardcoded
+from fiftyone import ViewField as F
+
+for flag_field in discovered_quality_fields:   # from get_field_schema() output
+    view_name = f"{flag_field}_samples"
+    dataset.save_view(view_name, dataset.match(F(flag_field) == True))
+    # Then load each in App for interactive review:
+    # execute_operator("@voxel51/operators/load_saved_view", params={"name": view_name})
+```
+
+Offer to tag flagged samples after user reviews them in the App:
+```
+tag_samples(["quality_issue"])
+```
+
+### Note on `bright` flag
+
+The `bright` threshold is calibrated for general-purpose datasets. For well-lit datasets (food photos, product images, studio shots), it may flag a large percentage (up to 100%) of samples as `bright`. This is a **known calibration artifact** — it does not mean the images are overexposed. In these cases:
+- Do NOT use the `bright` flag as a quality filter
+- Rely on `dark`, `blurry`, `low_contrast`, and `low_saturation` instead
+- Inform the user if `bright` flags > 80% of samples
+
+---
+
+## 8. Brightness Analysis (fallback)
+
+> **Skip this section if the `jacobmarks/image_issues` plugin was run** — brightness extremes and exposure are already covered by the plugin.
+
+If the plugin is not available and metadata mean values exist:
+
+```
+mean("metadata.mean")
+std("metadata.mean")
+histogram_values("metadata.mean", bins=20)
+```
+
+- Very low mean (< 30 for 8-bit) → potentially underexposed / night images
+- Very high mean (> 225) → overexposed / blown-out
+- Bimodal distribution → two distinct lighting conditions (day + night)
+
+Offer to tag if these represent quality issues or valid domain subsets (e.g., `"night"` intentionally).
+
+---
+
+## 9. Tag-and-Review Pattern
+
+After flagging samples in any quality check:
+
+1. **Tag** samples with a descriptive tag (e.g., `"corrupted"`, `"low_resolution"`, `"blurry"`, `"aspect_outlier"`)
+   ```
+   tag_samples(["<quality_tag>"])
+   ```
+2. **Review in App** — direct user to the FiftyOne App (use get_session_info() to get the URL)
+3. **Confirm action** — ask whether to:
+   - Exclude from downstream views (`dataset.exclude_by("tags", "<quality_tag>")`)
+   - Delete permanently (`dataset.delete_samples(view)` — only after explicit confirmation)
+   - Keep but track (leave tagged)
+
+---
+
+## 10. CLIPScore Alignment (Captioned / Multimodal Datasets)
+
+For datasets that have both images and text captions (e.g., image-caption pairs, VQA datasets):
+
+**Purpose**: Detect misaligned caption-image pairs where the caption does not describe the image.
+
+### Prerequisite
+A CLIP similarity index must exist or be computed first (Phase 5 of SKILL.md).
+
+### Workflow
+
+```
+list_operators(builtin_only=False)
+```
+
+If `@voxel51/brain/compute_similarity` with CLIP is available:
+
+1. Compute CLIP embeddings for images
+2. Use `sort_by_similarity` with the caption text to score alignment
+3. Flag samples with low similarity scores
+
+**Threshold guideline**: CLIPScore < 21.8 (cosine similarity × 100) indicates poor alignment (from published CLIP research). Tune to dataset.
+
+### Tagging low-alignment samples
+```
+tag_samples(["low_clip_alignment"])
+```
+
+---
+
+## 11. Export Clean Subset
+
+After all quality filters are applied and confirmed:
+
+```python
+# Python SDK guidance
+from fiftyone import ViewField as F
+
+# Discover quality flag fields via get_field_schema() first — do not hardcode
+# Then build the filter from discovered fields:
+quality_filters = (
+    (F("blurry") == False) &
+    (F("low_contrast") == False) &
+    (F("low_saturation") == False) &
+    (F("weird_aspect_ratio") == False)
+)
+
+# Add uniqueness filter if computed
+# quality_filters = quality_filters & (F("uniqueness") >= 0.3)
+
+clean_view = dataset.match(quality_filters)
+
+# Save named view
+dataset.save_view(f"{dataset.name}_clean", clean_view)
+
+# Clone to a new persistent dataset (confirm with user first)
+clean_dataset = clean_view.clone(
+    name=f"{dataset.name}_clean",
+    persistent=True
+)
+```
+
+Confirm the clone with the user before executing. Report the final sample count of the clean dataset.
+
+---
+
+## Quality Metrics Summary Table
+
+| Metric | MCP tool | Python SDK alternative |
+|--------|----------|----------------------|
+| Corruption | `set_view(filters={"metadata": null})` | `match(F("metadata") == None)` |
+| Resolution | `bounds("metadata.width/height")` | `match(F("metadata.width") >= N)` |
+| Aspect ratio | N/A (ViewField only) | `match(long_filter)` |
+| File size | `bounds("metadata.size_bytes")` | `match(F("metadata.size_bytes") < N)` |
+| Color channels | N/A (ViewField only) | `match(F("metadata.num_channels") != 3)` |
+| Blur, brightness, contrast, saturation | `jacobmarks/image_issues` plugin (preferred) | File-size heuristic fallback |
+| Brightness (fallback) | `mean("metadata.mean")` | `match(F("metadata.mean") < N)` |
+| CLIPScore | `sort_by_similarity` + CLIP | `compute_similarity` + `sort_by_similarity` |

--- a/skills/fiftyone-dataset-curation/SKILL.md
+++ b/skills/fiftyone-dataset-curation/SKILL.md
@@ -1,0 +1,752 @@
+---
+name: fiftyone-dataset-curation
+description: End-to-end dataset curation for FiftyOne: inspect schema and quality, audit annotations, analyze class distributions, explore embeddings, find duplicates, create curated subsets, and build train/val/test splits. Works with any computer vision dataset type.
+---
+
+# FiftyOne Dataset Curation
+
+End-to-end curation pipeline for any FiftyOne dataset: images, video, point clouds, grouped multimodal. Run all phases sequentially or jump directly to any single phase.
+
+## Key Directives
+
+**ALWAYS follow these rules — no exceptions:**
+
+### 1. Check for a loaded dataset first
+```
+list_datasets()
+```
+If none exists, offer to delegate to `fiftyone-dataset-import` skill.
+
+### 2. Set context before any operation
+```
+set_context(dataset_name="<name>")
+```
+
+### 3. Launch App before any brain operator
+```
+launch_app()
+```
+Wait 5–10 seconds for initialization before executing delegated operators.
+
+### 4. Discover schema before referencing any field
+```
+dataset_summary()
+get_field_schema(flat=True)
+```
+Never hardcode field names. Adapt all field references from schema discovery results.
+
+### 5. Discover operators dynamically
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="<uri>")
+```
+Always call `list_operators()` before any `execute_operator()`. Confirm the operator exists.
+
+### 6. Confirm before mutating
+Before tagging, adding fields, or deleting — present findings to the user and ask for confirmation.
+
+### 7. Keep App open for interactive review
+Do NOT call `close_app()` automatically. Leave the App running so the user can explore results.
+
+### 8. Check delegated service before brain operations
+Before running any brain operator with `delegate=True`, verify the delegated service is running:
+```bash
+fiftyone delegated list
+```
+If no services are running:
+```bash
+fiftyone delegated launch &
+```
+Wait ~5 seconds for initialization. Without this service, delegated operators will queue but never execute.
+
+### 9. Always discover plugin names dynamically
+Never assume a plugin's exact name or operator URI from documentation. Always verify:
+```
+list_plugins()
+```
+Use the exact plugin name from the output. Then:
+```
+list_operators(builtin_only=False)
+```
+Use the exact operator URI from the output. Documentation names may differ from installed names.
+
+### 10. Generate interactive insights after each phase
+After computing any metric (uniqueness, quality, similarity, etc.):
+1. Calculate counts of flagged/notable samples
+2. Create named saved views for the findings
+3. Load the view in the App automatically
+4. Present a narrative insight to the user
+5. Offer to continue to the next phase
+
+See **Insight Generation Pattern** at the bottom of this file.
+
+---
+
+## Phase -1 — Curation Plan
+
+**Before doing anything else**, present a complete curation plan to the user. This sets expectations and allows them to choose which phases to run.
+
+```
+list_datasets()
+dataset_summary()
+get_field_schema(flat=True)
+```
+
+Present the plan:
+
+```
+## Curation Plan for <dataset_name>
+
+Dataset: <name> | <N> samples | <media_type>
+Label fields: <list from schema>
+Existing brain runs: <list or "none">
+
+### Phases I will run:
+  Phase 1 — Dataset Inspection        (schema, tags, class distribution)
+  Phase 2 — Data Quality Audit        (metadata, resolution, file size, image quality via jacobmarks/image_issues plugin)
+  Phase 3 — Near-Duplicate Detection  (via fiftyone-find-duplicates skill)
+  Phase 4 — Class Distribution        (imbalance, coverage gaps)
+  Phase 5 — Embedding Exploration     (CLIP UMAP, gap detection)
+  Phase 6 — Annotation Audit          (mistakenness — requires predictions field)
+  Phase 7 — Curated Subset & Splits   (clean view, train/val/test)
+  Phase 8 — Data Q&A                  (on-demand questions)
+
+### Phases I will SKIP (and why):
+  Phase 6 — No predictions field found. Run fiftyone-dataset-inference first.
+
+### What you'll get:
+  - Named saved views for each key finding (loadable in App)
+  - Interactive insights at each step
+  - A clean_<dataset_name> view with quality filters applied
+
+Ready to start? (yes / skip to phase X / select specific phases)
+```
+
+Wait for user confirmation before proceeding. If they want to skip phases or run only specific ones, adapt accordingly.
+
+---
+
+## Phase 0 — Dataset Loading (Optional)
+
+Run this phase only if no dataset is loaded yet.
+
+```
+list_datasets()
+```
+
+- If a dataset exists → `set_context(dataset_name="<name>")` and proceed to Phase 1.
+- If no dataset exists → delegate to `fiftyone-dataset-import` skill.
+
+After loading:
+```
+dataset_summary()
+```
+
+Confirm with user:
+- Media type (image, video, point-cloud, group)
+- Sample count
+- Whether `persistent=True` is set
+
+---
+
+## Phase 1 — Dataset Inspection
+
+**MCP tools:** `dataset_summary`, `get_field_schema`, `count_values`, `distinct`
+
+### Steps
+
+```
+dataset_summary()
+get_field_schema(flat=True)
+count_values("tags")
+```
+
+From the schema, identify label fields (Detections, Classifications, Keypoints, Segmentation, Polylines, etc.) and run:
+```
+distinct("<label_field>.label")
+```
+Adapt the field path from the schema — never assume a field name.
+
+### Report to user
+
+Present a summary with:
+- Media type and sample count
+- All field names and their types
+- Existing tags and counts
+- Unique class names per label field
+- Any existing brain runs (embeddings, similarity indexes, mistakenness scores)
+- Missing or empty fields (flag these)
+- **Label type awareness**: Note whether label fields are Classifications vs. Detections — this affects which export formats are valid later
+
+### Export format note
+
+After identifying label types, inform the user:
+```
+Label type: Classification → supports Image Classification Directory Tree export
+Label type: Detection → supports COCO, YOLO, VOC export
+For COCO export with Classification labels → must run inference first (fiftyone-dataset-inference) to generate Detection labels
+```
+
+### Grouped dataset detection
+
+If `dataset_summary()` reports `media_type == "group"`:
+1. List available group slices from the schema
+2. Recommend operating on individual sensor slices for all curation phases:
+   ```python
+   # Python SDK equivalent (use for user guidance)
+   rgb_view = dataset.select_group_slices(["rgb_center"])
+   dataset.save_view("rgb_view", rgb_view)
+   ```
+3. Apply all subsequent brain operations to the slice view, not the full grouped dataset
+4. Use sensor-prefixed brain keys (e.g., `rgb_clip_umap`, `ir_clip_umap`)
+
+### Existing brain runs
+
+If brain runs are reported in `dataset_summary()`:
+- List them and their types (similarity, visualization, mistakenness, uniqueness, etc.)
+- Offer to reuse existing runs instead of recomputing
+- Ask user which phases to run and whether to skip phases with existing results
+
+---
+
+## Phase 2 — Data Quality Audit
+
+See `QUALITY-CHECKS.md` for the full deep-dive workflow.
+
+**MCP tools:** `execute_operator`, `bounds`, `histogram_values`, `mean`, `std`, `count_values`, `set_view`, `list_plugins`, `download_plugin`, `enable_plugin`
+
+### Minimum steps
+
+**Step 1: Compute metadata**
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/utils/compute_metadata")
+execute_operator(operator_uri="@voxel51/utils/compute_metadata", params={})
+```
+
+**Step 2: Check for corruption (null metadata)**
+```
+set_view(filters={"metadata": null})
+```
+If samples appear → report count; offer to tag them as `"corrupted"` after confirmation.
+
+**Step 3: Resolution analysis**
+```
+bounds("metadata.width")
+bounds("metadata.height")
+histogram_values("metadata.width", bins=20)
+histogram_values("metadata.height", bins=20)
+```
+
+**Step 4: File size analysis**
+```
+bounds("metadata.size_bytes")
+mean("metadata.size_bytes")
+std("metadata.size_bytes")
+```
+
+**Step 5: Aspect ratio**
+Report wide/tall outliers using ViewField pattern (see QUALITY-CHECKS.md).
+
+**Step 6: Image quality via jacobmarks plugin (REQUIRED for image datasets)**
+
+This is the primary method for detecting blur, brightness issues, contrast, saturation, and aspect ratio anomalies. Do NOT use custom cv2 code. Follow the discovery workflow:
+
+```
+list_plugins()
+```
+
+Find the entry matching "image_issues" or "image-quality". Note the exact plugin name from the output — **do not assume it matches the documentation name**.
+
+If not installed:
+```
+download_plugin(plugin_name="jacobmarks/image-quality-issues")
+```
+Then run `list_plugins()` again to confirm the installed name.
+
+Enable if disabled:
+```
+enable_plugin(plugin_name="<exact_name_from_list_plugins>")
+```
+
+Discover operator URIs:
+```
+list_operators(builtin_only=False)
+```
+
+Find operators matching `find_issues`, `compute_blurriness`, `compute_brightness`, etc. Use exact URIs.
+
+Run each issue check (delegated, one at a time). Use the exact operator URI from `list_operators()`:
+```
+execute_operator(
+    operator_uri="<uri_from_list_operators>",   # e.g. @jacobmarks/image_issues/find_issues
+    params={"issue_mode": "SINGLE", "issue": "blurry"},
+    delegate=True
+)
+```
+
+Wait for completion via `list_delegated_operations()` before running the next issue check. Repeat for: `low_contrast`, `low_saturation`, `weird_aspect_ratio`, `dark`, `bright` (see note on `bright` in QUALITY-CHECKS.md).
+
+After all checks complete:
+```
+get_field_schema(flat=True)
+```
+Identify the boolean flag fields added (e.g., `blurry`, `low_contrast`, `low_saturation`, `weird_aspect_ratio`).
+
+Generate interactive insights — see **Insight Generation Pattern** below.
+
+---
+
+## Phase 3 — Near-Duplicate Detection
+
+**Delegate to `fiftyone-find-duplicates` skill.**
+
+Tell the user:
+> "For near-duplicate detection, I'll use the `fiftyone-find-duplicates` skill."
+
+Recommended settings to suggest:
+- Model: `mobilenet-v2-imagenet-torch` (fast) or `clip-vit-base32-torch` (semantic)
+- Brain key: `img_sim`
+- Default threshold: 0.3
+
+After duplicates are identified and optionally removed, return here for Phase 4.
+
+---
+
+## Phase 4 — Class Distribution & Imbalance Analysis
+
+**MCP tools:** `count_values`, `histogram_values`, `distinct`, `bounds`, `mean`, `std`
+
+For each label field discovered in Phase 1:
+
+### Classification datasets
+```
+count_values("<label_field>.label")
+```
+
+### Detection datasets
+```
+count_values("<detections_field>.detections.label")
+histogram_values("<detections_field>.detections.confidence", bins=20)
+bounds("<detections_field>.detections.bounding_box")
+mean("<detections_field>.detections.confidence")
+```
+
+### Analysis to surface
+
+- **Class imbalance**: Classes with < 5% of total samples are underrepresented — flag them
+- **Confidence spread**: Bimodal distribution suggests uncertain predictions
+- **BBox size range**: Very small bboxes (< 1% of image area) may be low-quality annotations
+- **Metadata distributions**: If metadata fields exist (time of day, weather, sensor type, etc.), run `count_values` on them to surface coverage gaps:
+  ```
+  count_values("<metadata_field>")
+  ```
+  Adapt field paths from schema — do not assume any specific metadata fields exist.
+
+### Coverage gaps
+
+Report under-represented attribute combinations. Example guidance:
+- Few night-scene samples → recommend semantic search augmentation (Phase 5)
+- Rare class < 20 samples → flag for annotation priority
+
+---
+
+## Phase 5 — Embedding Exploration & Gap Detection
+
+**Delegate to `fiftyone-embeddings-visualization` skill.**
+
+Tell the user:
+> "For embedding visualization and gap detection, I'll use the `fiftyone-embeddings-visualization` skill."
+
+### Critical parameter: num_dims
+
+When calling `compute_visualization`, always include `num_dims`:
+```
+execute_operator(
+    operator_uri="@voxel51/brain/compute_visualization",
+    params={
+        "brain_key": "<key>",
+        "model": "clip-vit-base32-torch",
+        "method": "umap",
+        "num_dims": 2        # REQUIRED — operator fails without this
+    },
+    delegate=True
+)
+```
+
+### UMAP dependency
+
+`umap-learn` must be installed in the same Python environment as FiftyOne. If it fails:
+```bash
+# Find which python FiftyOne uses
+python3 -c "import fiftyone; print(fiftyone.__file__)"
+
+# Install to the correct environment
+/path/to/correct/python -m pip install umap-learn
+```
+
+### Recommended models
+
+- **CLIP** (`clip-vit-base32-torch`): Semantic similarity, supports text search → best for gap detection
+- **DINOv2** (`dinov2-vits14-torch`): Visual similarity → best for cluster exploration
+
+### Patch-level embeddings (detection datasets)
+
+For detection datasets, suggest patch-level embeddings after schema confirms a detections field:
+```
+get_operator_schema(operator_uri="@voxel51/brain/compute_visualization")
+execute_operator(
+    operator_uri="@voxel51/brain/compute_visualization",
+    params={
+        "patches_field": "<detections_field>",   # from schema discovery
+        "model": "clip-vit-base32-torch",
+        "method": "umap",
+        "num_dims": 2,
+        "brain_key": "<detections_field>_clip_umap"
+    },
+    delegate=True
+)
+```
+
+### Uniqueness computation
+
+After UMAP/similarity completes, compute uniqueness to find redundant samples:
+```
+execute_operator(
+    operator_uri="@voxel51/brain/compute_uniqueness",
+    params={},
+    delegate=True
+)
+```
+
+After completion, generate interactive insights:
+```
+bounds("uniqueness")
+histogram_values("uniqueness", bins=20)
+```
+
+Build named views:
+```python
+# Python SDK guidance — present these commands to user
+# Most redundant: bottom uniqueness scores
+dataset.save_view("redundant_samples", dataset.sort_by("uniqueness").limit(N))
+# Most diverse: top uniqueness scores
+dataset.save_view("most_unique", dataset.sort_by("uniqueness", reverse=True).limit(M))
+```
+
+Then load the insight view:
+```
+execute_operator("@voxel51/operators/load_saved_view", params={"name": "most_unique"})
+```
+
+### Semantic text search for subset discovery
+
+After CLIP similarity index exists:
+```
+execute_operator(
+    operator_uri="@voxel51/brain/sort_by_similarity",
+    params={"query": "foggy day", "k": 50, "brain_key": "<sim_key>"}
+)
+tag_samples(["foggy"])
+```
+Use text queries that match domain gaps found in Phase 4.
+
+---
+
+## Phase 6 — Annotation Audit
+
+See `ANNOTATION-AUDIT.md` for the full deep-dive workflow.
+
+**MCP tools:** `execute_operator`, `get_field_schema`, `set_view`, `tag_samples`
+
+### Prerequisite check
+
+Check if a predictions field exists:
+```
+get_field_schema(flat=True)
+```
+
+If no predictions field:
+> "Annotation audit (mistakenness) requires a predictions field. Delegate to `fiftyone-dataset-inference` skill first, then return here."
+
+> Note: If the dataset has Classification labels and you want COCO-compatible predictions, use `yolov8n-coco-torch` from the Zoo — it generates actual Detection bounding boxes.
+
+### Steps
+
+**Step 1: Compute mistakenness**
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/compute_mistakenness")
+execute_operator(
+    operator_uri="@voxel51/brain/compute_mistakenness",
+    params={
+        "pred_field": "<predictions_field>",    # from schema
+        "label_field": "<ground_truth_field>",  # from schema
+        "mistakenness_field": "mistakenness"
+    }
+)
+```
+
+**Step 2: Review high-mistakenness samples**
+```
+set_view(sort_by="mistakenness", reverse=True, limit=50)
+```
+Direct user to the FiftyOne App (use get_session_info() to get the URL) for visual review.
+
+**Step 3: Tag suspicious samples** (after user confirmation)
+```
+tag_samples(["annotation_review"])
+```
+
+**Step 4: Check possible missing annotations**
+```
+set_view(filters={"possible_missing": {"$gt": 0}})
+```
+
+Full annotation audit workflow in `ANNOTATION-AUDIT.md`.
+
+---
+
+## Phase 7 — Curated Subset Creation & Splits
+
+See `SUBSET-CREATION.md` for the full deep-dive workflow.
+
+**MCP tools:** `execute_operator`, `tag_samples`, `untag_samples`, `set_view`
+
+### Building the clean view
+
+After quality checks and duplicate detection, construct a clean view by combining all quality filters. Use `get_field_schema(flat=True)` to discover which boolean flag fields were added by the quality plugin — never hardcode field names.
+
+Example (adapt field names from schema):
+```python
+# Python SDK guidance — adapt field names from your schema
+from fiftyone import ViewField as F
+
+# Discover which quality flag fields exist via get_field_schema()
+# then build the filter expression from those fields only
+quality_filters = (F("blurry") == False) & (F("low_contrast") == False)
+
+# Add uniqueness filter if computed
+if "uniqueness" in field_schema:
+    quality_filters = quality_filters & (F("uniqueness") >= 0.3)  # tune threshold
+
+clean_view = dataset.match(quality_filters)
+dataset.save_view("clean_<dataset_name>", clean_view)
+```
+
+Then load in App:
+```
+execute_operator("@voxel51/operators/load_saved_view", params={"name": "clean_<dataset_name>"})
+```
+
+Report to user:
+- Total samples before cleaning
+- Samples removed per quality filter
+- Final clean sample count and percentage
+
+### Option A: Uniqueness-based diverse subset
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/compute_uniqueness")
+execute_operator(operator_uri="@voxel51/brain/compute_uniqueness", params={})
+set_view(sort_by="uniqueness", reverse=True, limit=<N>)
+tag_samples(["diverse"])
+```
+
+### Option B: Representativeness-based coreset
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/compute_representativeness")
+execute_operator(operator_uri="@voxel51/brain/compute_representativeness", params={})
+set_view(sort_by="representativeness", reverse=True, limit=<N>)
+tag_samples(["coreset"])
+```
+
+### Option C: Train/val/test splits
+```
+# Clear any existing split tags first
+untag_samples(["train", "val", "test"])
+
+# Python SDK guidance for user:
+# import fiftyone.utils.random as four
+# four.random_split(dataset, {"train": 0.70, "val": 0.15, "test": 0.15})
+```
+
+### Saving and cloning
+```
+# Python SDK guidance:
+# dataset.save_view("curated_subset", view)
+# view.clone(name="<dataset_name>_curated", persistent=True)
+```
+
+Full subset workflows in `SUBSET-CREATION.md`.
+
+---
+
+## Phase 8 — Data Q&A Interface
+
+Answer natural language questions about the dataset using aggregation MCP tools.
+
+**MCP tools:** `count_values`, `bounds`, `mean`, `std`, `distinct`, `histogram_values`, `dataset_summary`, `count_sample_tags`
+
+### Question → Tool mapping
+
+| User question | MCP tool |
+|---------------|----------|
+| "How many samples have no annotations?" | `set_view(exists=["<label_field>"])` then count |
+| "What is the class distribution?" | `count_values("<label_field>.label")` |
+| "What % of samples are night scenes?" | `count_values("<attribute_field>.label")` |
+| "What is the average bbox size?" | `mean("<detections_field>.detections.bounding_box")` |
+| "How many images are untagged?" | `count_sample_tags()` |
+| "What is the resolution range?" | `bounds("metadata.width")` + `bounds("metadata.height")` |
+| "How many duplicate samples were removed?" | `count_values("tags")` for relevant tag |
+| "What brain runs have been computed?" | `dataset_summary()` |
+| "How confident are the predictions?" | `histogram_values("<pred_field>.detections.confidence", bins=20)` |
+| "Are there any corrupted files?" | `set_view(filters={"metadata": null})` |
+
+Always adapt field paths from schema discovery — never assume field names exist.
+
+---
+
+## Insight Generation Pattern
+
+After any significant computation, generate and share interactive insights. This pattern applies after every phase.
+
+### Template
+
+1. **Compute aggregations** on the results:
+   ```
+   bounds("<score_field>")
+   histogram_values("<score_field>", bins=20)
+   mean("<score_field>")
+   ```
+
+2. **Calculate counts** for notable subsets:
+   ```
+   # Use set_view to count samples above/below thresholds
+   set_view(filters={"<flag_field>": True})
+   # Note the count from the response
+   ```
+
+3. **Create named saved views** via Python SDK (present as guidance to user):
+   ```python
+   # Present as Python SDK guidance
+   dataset.save_view("insight_<name>", <view_expression>)
+   ```
+
+4. **Load the view in App** using the load_saved_view operator:
+   ```
+   execute_operator("@voxel51/operators/load_saved_view", params={"name": "insight_<name>"})
+   ```
+
+5. **Present narrative insight** with counts and percentages:
+   ```
+   ## Insight: <Phase Name>
+
+   Found <N> samples (<X%>) flagged as <issue>.
+
+   Saved view "<insight_name>" is now loaded in the App.
+   → Visit the FiftyOne App (use get_session_info() to get the URL) to inspect these samples.
+
+   Would you like to:
+   - Tag these samples as "<tag>"
+   - Move to the next phase
+   - Dig deeper into this finding
+   ```
+
+### Example: After uniqueness computation
+
+```
+## Insight: Dataset Redundancy
+
+Uniqueness range: <min> → <max> (mean: <mean>)
+
+Bottom 10% by uniqueness (<N> samples) = highly redundant images — visually similar to many others.
+View "redundant_samples" is now loaded in the App.
+
+Top 20% by uniqueness (<M> samples) = maximally diverse images — best candidates for a training subset.
+View "most_unique" is now loaded in the App.
+
+Next up: Image quality checks (Phase 2). Continue?
+```
+
+---
+
+## Delegation Map
+
+| Sub-task | Delegated skill |
+|----------|----------------|
+| Import dataset if none loaded | `fiftyone-dataset-import` |
+| Near-duplicate detection | `fiftyone-find-duplicates` |
+| Embedding visualization | `fiftyone-embeddings-visualization` |
+| Predictions for mistakenness | `fiftyone-dataset-inference` |
+
+---
+
+## Production Patterns (Multimodal / Grouped Datasets)
+
+### Grouped dataset curation
+```python
+# Select sensor slice before brain ops (Python SDK guidance)
+rgb_view = dataset.select_group_slices(["rgb_center"])
+dataset.save_view("rgb_view", rgb_view)
+
+# Run brain ops on slice with sensor-prefixed keys
+# fob.compute_similarity(rgb_view, model="clip-vit-base32-torch", brain_key="rgb_img_sim")
+```
+
+### Check if similarity index supports text search
+```python
+# Python SDK guidance
+info = dataset.get_brain_info("rgb_img_sim")
+supports_text = info.config.supports_prompts  # True for CLIP-based
+```
+
+### Always save after field mutations
+```python
+# Python SDK guidance
+view.apply_model(model, "predictions")
+view.save()  # critical — never skip
+```
+
+### Thumbnail generation for large datasets (> 10k samples)
+```python
+# Python SDK guidance — improves App performance
+# foui.transform_images(view, size=(-1, 128), output_field="thumbnail_path", output_dir=...)
+# dataset.app_config.media_fields = ["filepath", "thumbnail_path"]
+# dataset.app_config.grid_media_field = "thumbnail_path"
+# dataset.save()
+```
+
+### ViewField patterns for quality filters
+```python
+from fiftyone import ViewField as F
+
+# Resolution
+F("metadata.width") > min_width
+F("metadata.height") > min_height
+
+# Color channels
+F("metadata.num_channels") == 3
+
+# Aspect ratio filters
+long_filter = F("metadata.width") > 2 * F("metadata.height")
+tall_filter  = F("metadata.height") > 2 * F("metadata.width")
+normal_aspect = (~long_filter) & (~tall_filter)
+
+# BBox area (relative)
+rel_bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
+
+# Annotation quality (after mistakenness computation)
+F("mistakenness") > 0.95
+F("possible_missing") > 0
+F("max_iou") > 0.75
+```
+
+---
+
+## Reference Files
+
+- `QUALITY-CHECKS.md` — Image quality filtering: metadata, blur, brightness, resolution, aspect ratio, CLIPScore
+- `ANNOTATION-AUDIT.md` — Annotation error detection: mistakenness, hardness, IoU dedup, side-by-side review
+- `SUBSET-CREATION.md` — Subset and split workflows: coreset, uniqueness, random split, saved views, cloning

--- a/skills/fiftyone-dataset-curation/SUBSET-CREATION.md
+++ b/skills/fiftyone-dataset-curation/SUBSET-CREATION.md
@@ -1,0 +1,445 @@
+# Curated Subset Creation & Splits
+
+Workflow for creating curated subsets, building train/val/test splits, saving named views, and cloning datasets in FiftyOne. All field references are discovered dynamically — never hardcoded.
+
+---
+
+## Overview
+
+Subset creation options (choose one or combine):
+
+| Method | Best for |
+|--------|----------|
+| Semantic text search (CLIP) | Finding domain-specific subsets (e.g., "foggy day", "night scene") |
+| Uniqueness-based subset | Maximum diversity — training set augmentation |
+| Representativeness-based coreset | Minimum representative set — fast iteration / labeling budget |
+| Random split | Standard train/val/test with reproducibility |
+| Uniqueness-balanced split | Diverse val/test, representative train |
+| Tag-based filtering | Working with pre-existing tags from earlier phases |
+
+---
+
+## Prerequisites
+
+Before any subset creation:
+
+```
+dataset_summary()
+get_field_schema(flat=True)
+count_values("tags")
+```
+
+Check existing tags. If split tags (`train`, `val`, `test`) already exist, offer to clear them before creating new splits.
+
+Also check what quality flag fields exist from Phase 2 — these are used to build the clean view:
+```
+get_field_schema(flat=True)
+```
+
+---
+
+## 0. Build the Clean View First
+
+Before creating subsets or splits, build a clean view that excludes quality-flagged samples. This should always be done before any other subset creation.
+
+**Discover the quality flag fields from schema** — do not hardcode. Run `get_field_schema(flat=True)` and look for boolean fields added by the quality plugin (e.g., `blurry`, `low_contrast`, `low_saturation`, `weird_aspect_ratio`).
+
+```python
+# Python SDK guidance — adapt field names from your get_field_schema() output
+from fiftyone import ViewField as F
+
+# Build filter from discovered boolean flag fields
+# Only include fields that actually exist in the schema
+quality_filters = (F("blurry") == False)  # start with confirmed fields
+
+# Add others if they exist in schema:
+# quality_filters = quality_filters & (F("low_contrast") == False)
+# quality_filters = quality_filters & (F("low_saturation") == False)
+# quality_filters = quality_filters & (F("weird_aspect_ratio") == False)
+
+# Add uniqueness filter if computed (tune threshold to dataset)
+# quality_filters = quality_filters & (F("uniqueness") >= 0.3)
+
+clean_view = dataset.match(quality_filters)
+
+# Save with descriptive name
+dataset.save_view("clean_training_set", clean_view)
+```
+
+Load in App for user to confirm:
+```
+execute_operator("@voxel51/operators/load_saved_view", params={"name": "clean_training_set"})
+```
+
+Report:
+```
+Clean view: <N> samples (<X%> of original <total>)
+Removed:
+  - <quality_flag_field>: <n> samples   (repeat for each flag field in schema)
+  - low uniqueness (below threshold): <n> samples
+```
+
+Ask user to confirm the clean view before proceeding to splits.
+
+---
+
+## 1. Semantic Text Search Subsets (CLIP)
+
+**Requires:** CLIP similarity index (from Phase 5 of SKILL.md). Check `dataset_summary()` for existing brain runs.
+
+### Workflow
+
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/sort_by_similarity")
+```
+
+For each semantic category to extract:
+```
+execute_operator(
+    operator_uri="@voxel51/brain/sort_by_similarity",
+    params={"query": "<text description>", "k": <N>, "brain_key": "<sim_key>"}
+)
+tag_samples(["<category_tag>"])
+```
+
+### Example queries (adapt to dataset domain)
+
+```
+"foggy day"        → tag_samples(["foggy"])
+"night scene"      → tag_samples(["night"])
+"rainy weather"    → tag_samples(["rainy"])
+"crowded scene"    → tag_samples(["crowded"])
+"edge case"        → tag_samples(["edge_case"])
+"small objects"    → tag_samples(["small_objects"])
+```
+
+Confirm with user the query text and k value before tagging.
+
+**Note:** Check that the similarity index supports text prompts before attempting text search:
+```python
+# Python SDK guidance
+info = dataset.get_brain_info("<sim_key>")
+supports_text = info.config.supports_prompts  # True for CLIP-based
+```
+
+---
+
+## 2. Diverse Subset via Uniqueness
+
+**Operator:** `@voxel51/brain/compute_uniqueness`
+
+Selects samples that are maximally different from each other — best for training set diversity.
+
+### Step 1: Compute uniqueness
+
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/compute_uniqueness")
+execute_operator(
+    operator_uri="@voxel51/brain/compute_uniqueness",
+    params={"uniqueness_field": "uniqueness"}
+)
+```
+
+### Step 2: Sort and tag top-N unique samples
+
+Ask user for desired subset size N, then:
+```
+set_view(sort_by="uniqueness", reverse=True, limit=<N>)
+tag_samples(["diverse"])
+```
+
+### Step 3: Review in App
+
+Direct user to the FiftyOne App (use get_session_info() to get the URL) to inspect the diverse subset before finalizing.
+
+### Use case
+
+- Creating a maximally diverse training set from a large pool
+- Selecting diverse representative examples for active learning
+- Building a challenging test set
+
+---
+
+## 3. Coreset via Representativeness
+
+**Operator:** `@voxel51/brain/compute_representativeness`
+
+Selects samples that best represent the full dataset distribution — best for labeling budget optimization.
+
+### Step 1: Compute representativeness
+
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/compute_representativeness")
+execute_operator(
+    operator_uri="@voxel51/brain/compute_representativeness",
+    params={"representativeness_field": "representativeness"}
+)
+```
+
+### Step 2: Sort and tag top-N representative samples
+
+Ask user for coreset size N, then:
+```
+set_view(sort_by="representativeness", reverse=True, limit=<N>)
+tag_samples(["coreset"])
+```
+
+### Use case
+
+- Creating a minimal labeled set that represents the full data distribution
+- Reducing annotation costs while preserving coverage
+- Bootstrapping a model with a small but representative training set
+
+---
+
+## 4. Train/Val/Test Splits
+
+### Option A: Random split (recommended for most cases)
+
+**Always clear existing split tags first:**
+```
+untag_samples(["train", "val", "test"])
+```
+
+Then apply random split:
+```python
+# Python SDK guidance
+import fiftyone.utils.random as four
+
+four.random_split(
+    dataset,
+    {"train": 0.70, "val": 0.15, "test": 0.15},
+    seed=5151   # use seed for reproducibility
+)
+```
+
+Confirm the split ratios with user before running.
+
+### Option B: Uniqueness-balanced split (recommended for detection/rare-class datasets)
+
+Creates a diverse, hard test set while keeping representative samples for training.
+
+```python
+# Python SDK guidance
+
+# 1. Compute uniqueness (if not already done in Phase 7)
+# fob.compute_uniqueness(dataset)
+
+# 2. Sort by uniqueness descending
+unique_view = dataset.sort_by("uniqueness", reverse=True)
+
+# 3. Take top-N as test set (diverse and challenging)
+n_test = int(0.15 * len(dataset))
+n_val  = int(0.15 * len(dataset))
+test_ids = unique_view.head(n_test).values("id")
+val_ids  = unique_view.skip(n_test).head(n_val).values("id")
+
+# 4. Tag splits
+dataset.select(test_ids).tag_samples(["test"])
+dataset.select(val_ids).tag_samples(["val"])
+dataset.match_tags(["test", "val"], bool=False).tag_samples(["train"])
+```
+
+### Option C: Semantic split (for domain-specific validation)
+
+Use text search (CLIP) to put domain-specific scenarios in val/test:
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/sort_by_similarity")
+
+# Tag night scenes for val/test
+execute_operator(
+    operator_uri="@voxel51/brain/sort_by_similarity",
+    params={"query": "night scene", "k": <N>, "brain_key": "<sim_key>"}
+)
+tag_samples(["val"])
+
+# Tag foggy scenes for val/test
+execute_operator(
+    operator_uri="@voxel51/brain/sort_by_similarity",
+    params={"query": "foggy conditions", "k": <N>, "brain_key": "<sim_key>"}
+)
+tag_samples(["val"])
+
+# Tag remaining as train — confirm with user before running
+# Python SDK: dataset.match_tags(["val", "test"], bool=False).tag_samples(["train"])
+```
+
+### Viewing splits
+
+After tagging:
+```
+count_values("tags")
+```
+
+To work with split views:
+```python
+# Python SDK guidance
+train_view = dataset.match_tags(["train"])
+val_view   = dataset.match_tags(["val"])
+test_view  = dataset.match_tags(["test"])
+```
+
+### Resplit pattern (clear and redo)
+
+```
+untag_samples(["train", "val", "test"])   # always clear before resplit
+# then re-apply chosen split option above
+```
+
+---
+
+## 5. Saving Named Views
+
+Save views for team collaboration so others can load them without recomputing filters.
+
+```python
+# Python SDK guidance
+
+# Save a view
+dataset.save_view("curated_subset", curated_view)
+dataset.save_view("train_split", train_view)
+dataset.save_view("val_split", val_view)
+dataset.save_view("test_split", test_view)
+dataset.save_view("annotation_review", review_view)
+
+# List all saved views
+dataset.list_saved_views()
+
+# Load a saved view
+view = dataset.load_saved_view("curated_subset")
+```
+
+Suggest saving named views at the end of each phase so results are preserved and shareable.
+
+---
+
+## 6. Cloning to a New Dataset
+
+Clone the curated subset to a new persistent dataset. This creates an independent copy with all brain runs and saved views.
+
+Confirm with user before cloning:
+- New dataset name
+- Whether to include all brain runs
+
+```python
+# Python SDK guidance
+
+# Clone from a view
+curated_dataset = curated_view.clone(
+    name=f"{dataset.name}_curated",
+    persistent=True
+)
+
+# Or clone from a tag-matched view
+train_dataset = dataset.match_tags(["train"]).clone(
+    name=f"{dataset.name}_train",
+    persistent=True
+)
+```
+
+After cloning, verify:
+```
+list_datasets()
+set_context(dataset_name="<new_dataset_name>")
+dataset_summary()
+```
+
+---
+
+## 7. Exporting Splits (for Training Pipelines)
+
+After splits are tagged, export each split to the target training format.
+
+**Delegate to `fiftyone-dataset-export` skill** for this step.
+
+Common export patterns (via that skill):
+```python
+# Python SDK guidance — use fiftyone-dataset-export skill for MCP version
+
+# YOLO format
+train_view.export(
+    export_dir="./exports/yolo/train",
+    dataset_type=fo.types.YOLOv5Dataset,
+    label_field="<ground_truth_field>"   # from schema discovery
+)
+
+# COCO format
+val_view.export(
+    export_dir="./exports/coco/val",
+    dataset_type=fo.types.COCODetectionDataset,
+    label_field="<ground_truth_field>"
+)
+```
+
+---
+
+## 8. Patch-Level Object Curation (Detection Datasets)
+
+For detection datasets, operate at the object level rather than image level.
+
+### Prerequisites
+
+- Detections field exists (confirmed from schema in Phase 1)
+- CLIP similarity index computed at patch level (Phase 5)
+
+### Workflow
+
+```
+list_operators(builtin_only=False)
+get_operator_schema(operator_uri="@voxel51/brain/compute_visualization")
+execute_operator(
+    operator_uri="@voxel51/brain/compute_visualization",
+    params={
+        "patches_field": "<detections_field>",   # from schema discovery
+        "model": "clip-vit-base32-torch",
+        "method": "umap",
+        "num_dims": 2,                           # REQUIRED — operator fails without this
+        "brain_key": "<detections_field>_clip_umap"
+    },
+    delegate=True
+)
+```
+
+In the App Embeddings panel:
+- Switch to "Patches" mode
+- Each point = one object instance
+- Lasso-select clusters of objects → tag at object level
+- Find object-level outliers (rare objects, badly annotated objects)
+
+### Object-level tagging
+
+```python
+# Python SDK guidance
+# After lasso-selecting in App, tag the patch view:
+patches_view = dataset.to_patches("<detections_field>")
+# ... filter patches ...
+# patches_view.tag_labels(["outlier_object"])
+```
+
+---
+
+## Subset Creation Decision Guide
+
+```
+Is there a large pool of unannotated data?
+  → Use compute_representativeness coreset to select what to annotate
+
+Do you need a maximally diverse training set?
+  → Use compute_uniqueness → sort desc → take top-N
+
+Do you need a challenging test set?
+  → Use uniqueness-balanced split (diverse test) or semantic text search for edge cases
+
+Do you have a labeling budget constraint?
+  → Use coreset (representativeness) to maximize coverage per labeled sample
+
+Do you need standard reproducible splits?
+  → Use four.random_split with seed=5151
+
+Do you need to curate specific domain scenarios?
+  → Use CLIP text search to extract semantic subsets
+```


### PR DESCRIPTION
Summary
- New end-to-end dataset curation skill covering 8 phases: schema inspection, data quality audit, near-duplicate
detection, class distribution analysis, embedding exploration, annotation audit, subset creation, and data Q&A
- Adds QUALITY-CHECKS.md (incl. jacobmarks/image_issues plugin as primary quality method), ANNOTATION-AUDIT.md
(mistakenness, hardness, IoU dedup), and SUBSET-CREATION.md (coreset, uniqueness, splits, saved views)
- Registered in AGENTS.md and .claude-plugin/marketplace.json (14 total entries)