### PR TITLE
update fiftyone-voodo-design skill to used improved design system documentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
       "name": "fiftyone-voodo-design",
       "source": "./skills/fiftyone-voodo-design",
       "skills": "./",
-      "description": "Build FiftyOne UIs using VOODO (Voxel Official Design Ontology), the official React component library. Use when building plugin panels, creating interactive UIs, styling FiftyOne applications, or needing React components with proper design tokens. Fetches current component documentation dynamically from llms.txt."
+      "description": "Build FiftyOne UIs using VOODO (@voxel51/voodo), the official React component library. Use when building plugin panels, creating interactive UIs, styling FiftyOne applications, or needing React components with proper design tokens. Fetches complete component API reference dynamically."
     },
     {
       "name": "fiftyone-issue-triage",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,13 +184,14 @@ This repository contains skills for computer vision workflows using FiftyOne and
 - `@voxel51/voodo` npm package
 
 **Workflow summary:**
-1. Fetch current VOODO docs via WebFetch from llms.txt
-2. Identify needed components from docs
-3. Use design tokens for colors, spacing, typography
+1. Fetch the LLM reference via WebFetch from `voodo-llm-reference.md`
+2. Use design token enums (Size, Spacing, Variant, etc.) — never raw strings
+3. Follow composition patterns (FormField wraps controls, Stack for layout)
 4. Build panel following FiftyOne patterns (dark theme, responsive)
 
 **Documentation sources:**
-- WebFetch: `https://voodo.dev.fiftyone.ai/llms.txt`
+- WebFetch: `https://voodo.dev.fiftyone.ai/voodo-llm-reference.md` (complete component API, tokens, patterns)
+- Source repo: `https://github.com/voxel51/design-system`
 - Interactive Storybook: `https://voodo.dev.fiftyone.ai/`
 
 ### FiftyOne Create Notebook (`fiftyone-create-notebook/`)
@@ -471,10 +472,10 @@ When users want to report issues or provide feedback, **YOU (the agent) must aut
 - [FiftyOne LLM Docs](https://docs.voxel51.com/llms.txt) - Fetch this for comprehensive FiftyOne API reference
 - [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server)
 - [FiftyOne Plugins](https://github.com/voxel51/fiftyone-plugins)
-- [VOODO Design System](https://voodo.dev.fiftyone.ai/llms.txt) - Fetch this for React component documentation
+- [VOODO Design System](https://voodo.dev.fiftyone.ai/voodo-llm-reference.md) - Fetch this for React component documentation
 
 ## External Documentation
 
 When you need detailed FiftyOne API information beyond what's in the skills, fetch:
 - `https://docs.voxel51.com/llms.txt` - Complete FiftyOne documentation for LLMs
-- `https://voodo.dev.fiftyone.ai/llms.txt` - VOODO React component library docs
+- `https://voodo.dev.fiftyone.ai/voodo-llm-reference.md` - VOODO React component library docs

--- a/skills/fiftyone-voodo-design/SKILL.md
+++ b/skills/fiftyone-voodo-design/SKILL.md
@@ -1,58 +1,57 @@
 ---
 name: fiftyone-voodo-design
-description: Build FiftyOne UIs using VOODO (Voxel Official Design Ontology), the official React component library. Use when building plugin panels, creating interactive UIs, or styling FiftyOne applications. Fetches current documentation dynamically from llms.txt.
+description: Build FiftyOne UIs using VOODO (@voxel51/voodo), the official React component library. Use when building plugin panels, creating interactive UIs, or styling FiftyOne applications. Fetches complete component API reference dynamically.
 ---
 
 # VOODO Design System for FiftyOne
 
-VOODO is the official React component library for FiftyOne applications.
-
-**Documentation is fetched dynamically** - always get current components from llms.txt before writing code.
+VOODO (`@voxel51/voodo`) is the official React component library for FiftyOne applications. Source: https://github.com/voxel51/design-system
 
 ## Key Directive
 
-**ALWAYS fetch llms.txt BEFORE writing any UI code:**
+**ALWAYS fetch the LLM reference BEFORE writing any UI code:**
 
 ```
 WebFetch(
-    url="https://voodo.dev.fiftyone.ai/llms.txt",
-    prompt="List all available VOODO components with their variants and use cases"
+    url="https://voodo.dev.fiftyone.ai/voodo-llm-reference.md",
+    prompt="Read the complete VOODO component API, design tokens, and composition patterns"
 )
 ```
 
 This gives you:
-- All current components (buttons, inputs, toasts, etc.)
-- Available variants for each component
-- Design token categories (colors, spacing, typography)
-- Links to interactive Storybook docs
+- All design token enums with exact member values (Size, Spacing, Variant, Orientation, etc.)
+- Every component's props, types, defaults, and usage examples
+- Composition patterns for common layouts (forms, cards, lists, selects)
+- Anti-patterns to avoid (e.g. raw Tailwind vs. component props)
 
 ## Workflow
 
-### 1. Fetch component list
+### 1. Fetch the reference
 
 ```
 WebFetch(
-    url="https://voodo.dev.fiftyone.ai/llms.txt",
-    prompt="What VOODO components are available for building forms?"
+    url="https://voodo.dev.fiftyone.ai/voodo-llm-reference.md",
+    prompt="What VOODO components and tokens are available for building [describe UI]?"
 )
 ```
 
-### 2. Use components from the fetched list
+### 2. Use components and design tokens from the reference
+
+Always import from `@voxel51/voodo`. Always use enum values — never pass raw strings.
 
 ```typescript
-// Import only components that exist in llms.txt
-import { Button, Input, Select } from "@voxel51/voodo";
+import { Button, Input, Stack, Text, FormField } from "@voxel51/voodo";
+import { Orientation, Size, Spacing, Variant, TextColor } from "@voxel51/voodo";
 ```
 
-### 3. For detailed props, direct user to Storybook
+### 3. Follow composition patterns
 
-The llms.txt includes Storybook links for each component. For detailed prop documentation:
-
-```
-"For Button props and examples, see: https://voodo.dev.fiftyone.ai/?path=/docs/components-button--docs"
-```
-
-**Note**: Storybook is a JavaScript app - WebFetch cannot extract its content. Direct users to browse interactively.
+The reference includes patterns for:
+- **Forms**: Wrap controls in `<FormField>`, group with `<FormFieldGroup>`
+- **Layout**: Use `<Stack>` with `orientation`, `spacing`, `align`, `justify` props — not Tailwind flex classes
+- **Cards**: Use `<Card>` / `<RichCard>` for contained content
+- **Lists**: Use `Descriptor<T>[]` pattern with `<RichList>` or `<RichButtonGroup>`
+- **Feedback**: Use `<Toast>`, `<Tooltip>`, `<EmptyState>`
 
 ## Installation
 
@@ -64,25 +63,39 @@ The llms.txt includes Storybook links for each component. For detailed prop docu
 }
 ```
 
+Import the theme CSS in your app entry point:
+
+```typescript
+import "@voxel51/voodo/theme.css";
+```
+
 ## FiftyOne Patterns
 
 - **Dark theme**: FiftyOne App uses dark mode by default
-- **Semantic variants**: Use success/danger/warning for actions (verify names from llms.txt)
-- **Design tokens**: Use spacing/color tokens instead of arbitrary values
+- **Semantic variants**: Use `Variant.Success`, `Variant.Danger`, `Variant.Secondary` for actions
+- **Design tokens**: Always use enum values (`Spacing.Md`, `Size.Sm`) — never arbitrary CSS values
+- **Layout**: Use `<Stack>` with `align` and `justify` props instead of Tailwind `items-*` / `justify-*` classes
 
 ## Integration with FiftyOne SDK
 
 ```typescript
 import { useRecoilValue } from "recoil";
 import * as fos from "@fiftyone/state";  // Standard FiftyOne alias
-import { Button, Text, Stack } from "@voxel51/voodo";
+import { Button, Text, Stack, FormField, Input } from "@voxel51/voodo";
+import { Orientation, Spacing, Size, Variant, TextColor } from "@voxel51/voodo";
 
 const MyPanel: React.FC = () => {
   const dataset = useRecoilValue(fos.dataset);
   return (
-    <Stack>
-      <Text>{dataset?.name}</Text>
-      <Button>Process</Button>
+    <Stack orientation={Orientation.Column} spacing={Spacing.Md}>
+      <Text color={TextColor.Secondary}>{dataset?.name}</Text>
+      <FormField
+        label="Filter"
+        control={<Input size={Size.Sm} placeholder="Search..." />}
+      />
+      <Button variant={Variant.Primary} size={Size.Sm}>
+        Process
+      </Button>
     </Stack>
   );
 };
@@ -92,7 +105,8 @@ const MyPanel: React.FC = () => {
 
 | Resource | URL |
 |----------|-----|
-| **llms.txt** (fetch first) | https://voodo.dev.fiftyone.ai/llms.txt |
+| **LLM Reference** (fetch first) | https://voodo.dev.fiftyone.ai/voodo-llm-reference.md |
+| **Source repo** | https://github.com/voxel51/design-system |
 | **Interactive Storybook** | https://voodo.dev.fiftyone.ai/ |
 | **npm package** | `@voxel51/voodo` |
 
@@ -102,6 +116,7 @@ const MyPanel: React.FC = () => {
 
 | Problem | Solution |
 |---------|----------|
-| Component not found | Fetch llms.txt to verify current name |
-| Props not working | Direct user to Storybook for current API |
-| Styles not applying | Test in dark mode, use design tokens |
+| Component not found | Fetch the LLM reference to verify current component name |
+| Wrong prop value | Use enum members (e.g. `Size.Md`), not strings (e.g. `"md"`) |
+| Layout not working | Use `<Stack>` with `orientation`, `spacing`, `align`, `justify` props |
+| Styles not applying | Ensure `@voxel51/voodo/theme.css` is imported; test in dark mode |


### PR DESCRIPTION
This PR updates the `fiftyone-voodo-design` skill to point to improved design system documentation. This should yield better results when generating frontend code, with closer alignment to VOODO best-practices.