### PR TITLE
Add contribution infrastructure, issue templates, and CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug Report
+description: Report incorrect or broken skill behavior
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! This template is for **broken skill behavior** — cases where the skill gave wrong instructions or failed in an unexpected way.
+
+        > **Tip:** For interactive debugging, ask your AI assistant `"Help me submit feedback about [issue]"` — it will automatically gather your session context and environment info.
+
+  - type: input
+    id: skill_name
+    attributes:
+      label: Skill Name
+      description: Which skill is affected? (e.g., `fiftyone-find-duplicates`)
+      placeholder: fiftyone-my-skill
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_went_wrong
+    attributes:
+      label: What did the skill do wrong?
+      description: Describe the incorrect behavior clearly.
+      placeholder: The skill told the agent to call `compute_similarity` before launching the App, which caused an executor error.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this? Include the prompt you gave the AI assistant.
+      placeholder: |
+        1. Load the `fiftyone-find-duplicates` skill
+        2. Say: "Find duplicate images in my quickstart dataset"
+        3. Agent called `execute_operator` with `@voxel51/brain/compute_similarity` before launching the App
+        4. Got error: "Executor not available"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What should the skill have instructed the agent to do?
+      placeholder: The skill should instruct the agent to launch the App first, then call compute_similarity.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ai_assistant
+    attributes:
+      label: AI Assistant Used
+      options:
+        - Claude Code
+        - Cursor
+        - Codex / OpenCode
+        - Gemini CLI
+        - Goose
+        - Amp
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: fiftyone_version
+    attributes:
+      label: FiftyOne Version
+      placeholder: "1.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: mcp_version
+    attributes:
+      label: MCP Server Version (if applicable)
+      placeholder: "0.1.0"
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Logs, screenshots, or anything else that helps explain the issue

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,7 +61,7 @@ body:
         - Gemini CLI
         - Goose
         - Amp
-        - Other
+        - Other (specify in "Details" section)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/new_skill.yml
+++ b/.github/ISSUE_TEMPLATE/new_skill.yml
@@ -1,0 +1,85 @@
+name: New Skill Proposal
+description: Propose a new skill or workflow for FiftyOne Skills
+title: "[New Skill]: "
+labels: ["new-skill", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a new skill! Skills teach AI assistants to perform complex computer vision workflows autonomously.
+
+        Before submitting, check [existing skills](https://github.com/voxel51/fiftyone-skills/tree/main/skills) and [open proposals](https://github.com/voxel51/fiftyone-skills/issues?q=is%3Aopen+label%3Anew-skill) to avoid duplicates.
+
+  - type: input
+    id: skill_name
+    attributes:
+      label: Skill Name
+      description: Proposed skill directory name (e.g., `fiftyone-active-learning`)
+      placeholder: fiftyone-my-skill
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What does this skill do?
+      description: Describe the workflow this skill would enable. What can an AI assistant do with it?
+      placeholder: |
+        This skill guides an AI assistant to run active learning cycles on a FiftyOne dataset —
+        selecting the most informative unlabeled samples for annotation using brain similarity.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Who would use it and when?
+      placeholder: |
+        Data scientists spending time manually selecting samples for labeling.
+        This skill would automate the selection step using FiftyOne's brain methods.
+    validations:
+      required: true
+
+  - type: textarea
+    id: fiftyone_features
+    attributes:
+      label: FiftyOne Features / Operators Used
+      description: Which FiftyOne operators, brain methods, or plugins would this skill rely on?
+      placeholder: |
+        - `@voxel51/brain/compute_similarity`
+        - `@voxel51/brain/compute_representativeness`
+        - `fiftyone.brain.compute_uniqueness`
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: ai_assistants
+    attributes:
+      label: Target AI Assistants
+      description: Which AI assistants are you targeting or have tested with?
+      options:
+        - label: Claude Code
+        - label: Cursor
+        - label: Codex / OpenCode
+        - label: Gemini CLI
+        - label: Goose
+        - label: Other
+
+  - type: dropdown
+    id: willing_to_implement
+    attributes:
+      label: Are you willing to implement this?
+      options:
+        - "Yes — I'll submit a PR"
+        - "Maybe — I'd need some guidance"
+        - "No — just proposing the idea"
+    validations:
+      required: true
+
+  - type: input
+    id: discord
+    attributes:
+      label: Discord Handle (optional)
+      description: Join us at discord.gg/fiftyone-community to discuss this proposal
+      placeholder: yourhandle

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Related Issues
+
+<!-- Link issues with keywords: "Closes #123" or "Fixes #123" -->
+
+## What does this PR do?
+
+<!-- 1-2 sentence description of the change -->
+
+## Type of Change
+
+- [ ] New skill
+- [ ] Skill improvement (bug fix, better instructions, edge cases)
+- [ ] New agent integration
+- [ ] Documentation / repo infrastructure
+- [ ] Other
+
+## Skill Checklist
+
+<!-- Complete this section if you're adding or modifying a skill -->
+
+- [ ] `SKILL.md` has YAML frontmatter with `name` and `description`
+- [ ] Key Directives section is present (ALWAYS/NEVER rules)
+- [ ] Complete Workflow section with code examples at each step
+- [ ] Troubleshooting section covers common failure modes
+- [ ] `AGENTS.md` updated with the skill entry
+- [ ] Tested end-to-end with at least one AI assistant
+- [ ] `node scripts/validate-template.mjs` passes
+
+## Testing
+
+<!-- How did you test this? Which AI assistant(s) did you use? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 
 <!-- Complete this section if you're adding or modifying a skill -->
 
-- [ ] `SKILL.md` has YAML frontmatter with `name` and `description`
+- [ ] `SKILL.md` has YAML frontmatter with, `name` and `description` at least and all keys are universally valid
 - [ ] Key Directives section is present (ALWAYS/NEVER rules)
 - [ ] Complete Workflow section with code examples at each step
 - [ ] Troubleshooting section covers common failure modes

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,21 @@
+name: Validate Skills
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Validate skill templates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run template validator
+        run: node scripts/validate-template.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,6 @@ Thumbs.db
 # Logs
 *.log
 
-# Validation scripts (local-only, from cursor/plugin-template)
-scripts/
-
 # Notebook test outputs
 *_output.ipynb
 .notebook-test-env/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,180 @@
+# Contributing to FiftyOne Skills
+
+Thank you for your interest in contributing! FiftyOne Skills are packaged workflows that teach AI assistants to perform complex computer vision tasks, and the community is what makes them better.
+
+> **New here?** Browse [open issues](https://github.com/voxel51/fiftyone-skills/issues?q=is%3Aopen+label%3A%22help+wanted%22) labeled `help wanted` or `good first issue` to find a great starting point.
+
+## Ways to Contribute
+
+There are two main ways to contribute:
+
+- **New skill** — Teach an AI assistant a workflow it doesn't know yet
+- **Improve an existing skill** — Fix a bug, improve accuracy, add edge cases, or add supporting reference docs
+
+Both follow the same workflow below.
+
+## Before You Start
+
+1. **Check existing skills** — Browse [`skills/`](skills/) to make sure there isn't already a skill that covers your use case
+2. **Check open issues** — Someone may already be working on it, or there may be useful context in an existing issue
+3. **Look at the roadmap** — See [GitHub Milestones](https://github.com/voxel51/fiftyone-skills/milestones) and issues labeled [`roadmap`](https://github.com/voxel51/fiftyone-skills/labels/roadmap) for planned work
+
+No approval needed — just submit your PR when it's ready.
+
+## Contribution Workflow
+
+### 1. Fork and clone
+
+```bash
+git clone https://github.com/<your-username>/fiftyone-skills.git
+cd fiftyone-skills
+```
+
+### 2. Create a branch
+
+```bash
+git checkout -b feat/fiftyone-my-skill
+```
+
+Branch naming: `feat/<skill-name>` for new skills, `fix/<skill-name>` for improvements.
+
+### 3. Copy the closest existing skill as a starting point
+
+```bash
+cp -r skills/fiftyone-find-duplicates skills/fiftyone-my-skill
+```
+
+For simple skills, `fiftyone-find-duplicates` is a good template.  
+For MCP-heavy skills, use `fiftyone-dataset-import`.  
+For plugin development, use `fiftyone-develop-plugin`.
+
+### 4. Write your `SKILL.md`
+
+See the [Skill Structure](#skill-structure) section below for the required format.
+
+### 5. Test with your AI assistant
+
+Load the skill and run through your workflow end-to-end. The skill should guide the agent correctly without manual correction.
+
+**Claude Code:**
+```bash
+/plugin install fiftyone-my-skill@fiftyone-skills
+```
+
+### 6. Validate the template
+
+```bash
+node scripts/validate-template.mjs
+```
+
+This checks frontmatter, path safety, and naming conventions. Fix any errors before submitting.
+
+### 7. Update `AGENTS.md`
+
+Add an entry for your skill under the **Available Skills** section of `AGENTS.md`. Follow the existing format:
+
+```markdown
+### FiftyOne My Skill (`fiftyone-my-skill/`)
+
+**When to use:** [One sentence describing when an agent should load this skill]
+
+**Instructions:** Load the skill file at `skills/fiftyone-my-skill/SKILL.md`
+
+**Key requirements:**
+- [Any dependencies, plugins, or MCP tools required]
+
+**Workflow summary:**
+1. Step one
+2. Step two
+3. ...
+```
+
+### 8. Submit a Pull Request
+
+Push your branch and open a PR against `main`. The PR template will guide you through the checklist.
+
+## Skill Structure
+
+Each skill lives in its own directory under `skills/`:
+
+```
+skills/
+└── fiftyone-my-skill/
+    ├── SKILL.md              # Required — instructions for the AI
+    ├── references/           # Optional — supporting reference docs
+    │   └── SOME-GUIDE.md
+    └── scripts/              # Optional — example or utility scripts
+        └── example.py
+```
+
+### `SKILL.md` format
+
+Every `SKILL.md` must start with YAML frontmatter:
+
+```markdown
+---
+name: fiftyone-my-skill
+description: One to two sentences describing when to use this skill and what it does.
+---
+```
+
+The `description` field is what triggers skill activation — write it to match how a user would naturally phrase the task.
+
+### Required sections
+
+| Section | Purpose |
+|---------|---------|
+| **Key Directives** | `ALWAYS`/`NEVER` rules the agent must follow |
+| **Complete Workflow** | Step-by-step instructions with code examples |
+| **Troubleshooting** | Common errors, their causes, and fixes |
+
+### Recommended sections
+
+| Section | Purpose |
+|---------|---------|
+| Available Tools | Table of MCP tools or operators used |
+| Common Use Cases | 2–3 real-world examples |
+| Best Practices | Tips for reliable results |
+| Resources | Links to docs, plugins, or related skills |
+
+### Quality bar
+
+Before submitting, verify your skill:
+
+- [ ] Frontmatter has `name` and `description`
+- [ ] `description` triggers on realistic user prompts (not too broad, not too narrow)
+- [ ] Key Directives covers the most important rules (5–8 items)
+- [ ] Workflow has code examples at each step
+- [ ] Troubleshooting covers the most common failure modes
+- [ ] Tested end-to-end with at least one AI assistant
+
+## Naming Conventions
+
+- Skill directories: `fiftyone-<name>` (kebab-case, lowercase)
+- Supporting docs: `UPPER-CASE.md` (e.g., `HF-HUB-IMPORT.md`, `FIELD-MAPPING.md`)
+- Scripts: `snake_case.py` or `kebab-case.mjs`
+
+## Supported AI Assistants
+
+Skills in this repo are tested against:
+
+| Assistant | Install method |
+|-----------|---------------|
+| Claude Code | `/plugin install` |
+| Cursor | `.cursor-plugin/` |
+| Gemini CLI | `gemini extensions install` |
+| Codex, Goose, Amp, and more | Universal installer |
+
+If your skill works with a specific assistant only, note it in the `SKILL.md` prerequisites.
+
+## Community
+
+- **Discord**: [FiftyOne Community](https://discord.gg/fiftyone-community) — get help, share your work, discuss ideas
+- **Issues**: [GitHub Issues](https://github.com/voxel51/fiftyone-skills/issues) — bugs, feature requests, proposals
+- **Feedback**: Ask your AI assistant `"Help me submit feedback about [issue]"` to auto-generate a report
+
+<div align="center">
+
+Copyright 2017–2026, Voxel51, Inc. · [Apache 2.0 License](LICENSE)
+
+</div>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Both follow the same workflow below.
 2. **Check open issues** — Someone may already be working on it, or there may be useful context in an existing issue
 3. **Look at the roadmap** — See [GitHub Milestones](https://github.com/voxel51/fiftyone-skills/milestones) and issues labeled [`roadmap`](https://github.com/voxel51/fiftyone-skills/labels/roadmap) for planned work
 
-No approval needed — just submit your PR when it's ready.
+No permission needed to start contributing — just submit your PR when it's ready.
 
 ## Contribution Workflow
 
@@ -147,6 +147,7 @@ Before submitting, verify your skill:
 - [ ] Workflow has code examples at each step
 - [ ] Troubleshooting covers the most common failure modes
 - [ ] Tested end-to-end with at least one AI assistant
+- [ ] No inclusion of device-specific references or local-only file pointers
 
 ## Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![FiftyOne](https://img.shields.io/badge/FiftyOne-v1.10+-orange.svg)](https://github.com/voxel51/fiftyone)
 [![MCP Server](https://img.shields.io/badge/MCP%20Server-fiftyone--mcp-green.svg)](https://github.com/voxel51/fiftyone-mcp-server)
+[![Validate Skills](https://github.com/voxel51/fiftyone-skills/actions/workflows/validate.yml/badge.svg)](https://github.com/voxel51/fiftyone-skills/actions/workflows/validate.yml)
 
 [![Discord](https://img.shields.io/badge/Discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/fiftyone-community)
 [![Hugging Face](https://img.shields.io/badge/Hugging_Face-purple?style=flat&logo=huggingface)](https://huggingface.co/Voxel51)
@@ -212,16 +213,11 @@ Common errors and solutions
 
 ## Contributing
 
-We welcome contributions! Here's how to create a new skill:
+We welcome contributions! Whether you want to add a new skill, improve an existing one, or help with integrations and tooling — there's a place for you here.
 
-1. **Fork** this repository
-2. **Copy** an existing skill folder (e.g., `skills/fiftyone-find-duplicates/`)
-3. **Update** `SKILL.md` with your workflow
-4. **Add** your skill to `.claude-plugin/marketplace.json`
-5. **Test** with your AI assistant
-6. **Submit** a Pull Request
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full guide, including skill structure requirements, the quality bar, and how to test your skill before submitting.
 
-See [find-duplicates SKILL.md](skills/fiftyone-find-duplicates/SKILL.md) for a complete example.
+Looking for ideas? Browse issues labeled [`help wanted`](https://github.com/voxel51/fiftyone-skills/labels/help%20wanted) or [`good first issue`](https://github.com/voxel51/fiftyone-skills/labels/good%20first%20issue), or check the [project milestones](https://github.com/voxel51/fiftyone-skills/milestones) for planned work.
 
 ## Feedback
 

--- a/scripts/validate-template.mjs
+++ b/scripts/validate-template.mjs
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const repoRoot = process.cwd();
+const errors = [];
+const warnings = [];
+
+const pluginNamePattern = /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+const marketplaceNamePattern = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+function addError(message) {
+  errors.push(message);
+}
+
+function addWarning(message) {
+  warnings.push(message);
+}
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureDirectory(targetPath, context) {
+  try {
+    const stat = await fs.stat(targetPath);
+    if (!stat.isDirectory()) {
+      addError(`${context} exists but is not a directory: ${targetPath}`);
+      return false;
+    }
+    return true;
+  } catch {
+    addError(`${context} directory is missing: ${targetPath}`);
+    return false;
+  }
+}
+
+async function readJsonFile(filePath, context) {
+  let raw;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch {
+    addError(`${context} is missing: ${filePath}`);
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    addError(`${context} contains invalid JSON (${filePath}): ${error.message}`);
+    return null;
+  }
+}
+
+function normalizeNewlines(content) {
+  return content.replace(/\r\n/g, "\n");
+}
+
+function parseFrontmatter(content) {
+  const normalized = normalizeNewlines(content);
+  if (!normalized.startsWith("---\n")) {
+    return null;
+  }
+
+  const closingIndex = normalized.indexOf("\n---\n", 4);
+  if (closingIndex === -1) {
+    return null;
+  }
+
+  const frontmatterBlock = normalized.slice(4, closingIndex);
+  const fields = {};
+
+  for (const line of frontmatterBlock.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separator = line.indexOf(":");
+    if (separator === -1) {
+      continue;
+    }
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    fields[key] = value;
+  }
+
+  return fields;
+}
+
+async function walkFiles(dirPath) {
+  const files = [];
+  const stack = [dirPath];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile()) {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function isSafeRelativePath(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    return false;
+  }
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    return true;
+  }
+  if (path.isAbsolute(value)) {
+    return false;
+  }
+  const normalized = path.posix.normalize(value.replace(/\\/g, "/"));
+  return !normalized.startsWith("../") && normalized !== "..";
+}
+
+function extractPathValues(value) {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractPathValues(entry));
+  }
+
+  if (value && typeof value === "object") {
+    const candidates = [];
+    if (typeof value.path === "string") {
+      candidates.push(value.path);
+    }
+    if (typeof value.file === "string") {
+      candidates.push(value.file);
+    }
+    return candidates;
+  }
+
+  return [];
+}
+
+async function validateReferencedPath(pluginDir, fieldName, pathValue, pluginName) {
+  if (pathValue.startsWith("http://") || pathValue.startsWith("https://")) {
+    return;
+  }
+
+  if (!isSafeRelativePath(pathValue)) {
+    addError(
+      `${pluginName}: field "${fieldName}" has invalid path "${pathValue}". Use a relative path without ".." or absolute prefixes.`
+    );
+    return;
+  }
+
+  const resolved = path.resolve(pluginDir, pathValue);
+  const exists = await pathExists(resolved);
+  if (!exists) {
+    addError(`${pluginName}: field "${fieldName}" references missing path "${pathValue}".`);
+  }
+}
+
+async function validateFrontmatterFile(filePath, componentName, requiredKeys, pluginName) {
+  const content = await fs.readFile(filePath, "utf8");
+  const parsed = parseFrontmatter(content);
+  const relativeFile = path.relative(repoRoot, filePath);
+
+  if (!parsed) {
+    addError(`${pluginName}: ${componentName} file missing YAML frontmatter: ${relativeFile}`);
+    return;
+  }
+
+  for (const key of requiredKeys) {
+    if (!parsed[key] || parsed[key].length === 0) {
+      addError(`${pluginName}: ${componentName} file missing "${key}" in frontmatter: ${relativeFile}`);
+    }
+  }
+}
+
+async function validateComponentFrontmatter(pluginDir, pluginName) {
+  const rulesDir = path.join(pluginDir, "rules");
+  if (await pathExists(rulesDir)) {
+    const files = await walkFiles(rulesDir);
+    for (const file of files) {
+      const ext = path.extname(file).toLowerCase();
+      if (ext === ".md" || ext === ".mdc" || ext === ".markdown") {
+        await validateFrontmatterFile(file, "rule", ["description"], pluginName);
+      }
+    }
+  }
+
+  const skillsDir = path.join(pluginDir, "skills");
+  if (await pathExists(skillsDir)) {
+    const files = await walkFiles(skillsDir);
+    for (const file of files) {
+      if (path.basename(file) === "SKILL.md") {
+        await validateFrontmatterFile(file, "skill", ["name", "description"], pluginName);
+      }
+    }
+  }
+
+  const agentsDir = path.join(pluginDir, "agents");
+  if (await pathExists(agentsDir)) {
+    const files = await walkFiles(agentsDir);
+    for (const file of files) {
+      const ext = path.extname(file).toLowerCase();
+      if (ext === ".md" || ext === ".mdc" || ext === ".markdown") {
+        await validateFrontmatterFile(file, "agent", ["name", "description"], pluginName);
+      }
+    }
+  }
+
+  const commandsDir = path.join(pluginDir, "commands");
+  if (await pathExists(commandsDir)) {
+    const files = await walkFiles(commandsDir);
+    for (const file of files) {
+      const ext = path.extname(file).toLowerCase();
+      if (ext === ".md" || ext === ".mdc" || ext === ".markdown" || ext === ".txt") {
+        await validateFrontmatterFile(file, "command", ["name", "description"], pluginName);
+      }
+    }
+  }
+}
+
+function resolveMarketplaceSource(source, pluginRoot) {
+  if (typeof source !== "string" || source.length === 0) {
+    return null;
+  }
+  if (!pluginRoot) {
+    return source;
+  }
+  const normalizedRoot = pluginRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+  const normalizedSource = source.replace(/\\/g, "/");
+  if (normalizedSource === normalizedRoot || normalizedSource.startsWith(`${normalizedRoot}/`)) {
+    return normalizedSource;
+  }
+  return `${normalizedRoot}/${normalizedSource}`;
+}
+
+async function main() {
+  const marketplacePath = path.join(repoRoot, ".cursor-plugin", "marketplace.json");
+  const marketplace = await readJsonFile(marketplacePath, "Marketplace manifest");
+  if (!marketplace) {
+    summarizeAndExit();
+    return;
+  }
+
+  if (typeof marketplace.name !== "string" || !marketplaceNamePattern.test(marketplace.name)) {
+    addError(
+      'Marketplace "name" must be lowercase kebab-case and start/end with an alphanumeric character.'
+    );
+  }
+
+  if (!marketplace.owner || typeof marketplace.owner.name !== "string" || marketplace.owner.name.length === 0) {
+    addError('Marketplace "owner.name" is required.');
+  }
+
+  if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+    addError('Marketplace "plugins" must be a non-empty array.');
+    summarizeAndExit();
+    return;
+  }
+
+  const pluginRoot = marketplace.metadata?.pluginRoot;
+  if (pluginRoot !== undefined) {
+    if (typeof pluginRoot !== "string" || !isSafeRelativePath(pluginRoot)) {
+      addError('Marketplace "metadata.pluginRoot" must be a safe relative path.');
+    } else {
+      const pluginRootAbs = path.join(repoRoot, pluginRoot);
+      await ensureDirectory(pluginRootAbs, 'Marketplace "metadata.pluginRoot"');
+    }
+  }
+
+  const seenNames = new Set();
+  for (const [index, entry] of marketplace.plugins.entries()) {
+    const label = `plugins[${index}]`;
+
+    if (!entry || typeof entry !== "object") {
+      addError(`${label} must be an object.`);
+      continue;
+    }
+
+    if (typeof entry.name !== "string" || !pluginNamePattern.test(entry.name)) {
+      addError(`${label}.name must be lowercase and use only alphanumerics, hyphens, and periods.`);
+      continue;
+    }
+
+    if (seenNames.has(entry.name)) {
+      addError(`Duplicate plugin name in marketplace manifest: "${entry.name}"`);
+    }
+    seenNames.add(entry.name);
+
+    const sourcePath = resolveMarketplaceSource(entry.source, pluginRoot ?? "");
+    if (!sourcePath) {
+      addError(`${label}.source must be a string path.`);
+      continue;
+    }
+    if (!isSafeRelativePath(sourcePath)) {
+      addError(`${label}.source is not a safe relative path: "${sourcePath}"`);
+      continue;
+    }
+
+    const pluginDir = path.join(repoRoot, sourcePath);
+    const pluginDirExists = await ensureDirectory(pluginDir, `${label}.source`);
+    if (!pluginDirExists) {
+      continue;
+    }
+
+    const manifestPath = path.join(pluginDir, ".cursor-plugin", "plugin.json");
+    const pluginManifest = await readJsonFile(manifestPath, `${entry.name} plugin manifest`);
+    if (!pluginManifest) {
+      continue;
+    }
+
+    if (typeof pluginManifest.name !== "string" || !pluginNamePattern.test(pluginManifest.name)) {
+      addError(
+        `${entry.name}: "name" in plugin.json must be lowercase and use only alphanumerics, hyphens, and periods.`
+      );
+    }
+
+    if (pluginManifest.name && pluginManifest.name !== entry.name) {
+      addError(
+        `${entry.name}: marketplace entry name does not match plugin.json name ("${pluginManifest.name}").`
+      );
+    }
+
+    const manifestFields = ["logo", "rules", "skills", "agents", "commands", "hooks", "mcpServers"];
+    for (const field of manifestFields) {
+      const values = extractPathValues(pluginManifest[field]);
+      for (const value of values) {
+        await validateReferencedPath(pluginDir, field, value, entry.name);
+      }
+    }
+
+    await validateComponentFrontmatter(pluginDir, entry.name);
+
+    const hooksPath = path.join(pluginDir, "hooks", "hooks.json");
+    if (!(await pathExists(hooksPath))) {
+      addWarning(`${entry.name}: no hooks/hooks.json file found (only needed when using hooks).`);
+    }
+
+    const mcpPath = path.join(pluginDir, ".mcp.json");
+    if (!(await pathExists(mcpPath))) {
+      addWarning(`${entry.name}: no .mcp.json file found (only needed when using MCP servers).`);
+    }
+  }
+
+  summarizeAndExit();
+}
+
+function summarizeAndExit() {
+  if (warnings.length > 0) {
+    console.log("Warnings:");
+    for (const warning of warnings) {
+      console.log(`- ${warning}`);
+    }
+    console.log("");
+  }
+
+  if (errors.length > 0) {
+    console.error("Validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Validation passed.");
+}
+
+await main();


### PR DESCRIPTION
## Summary
* Adds `CONTRIBUTING.md` with a complete guide for creating and improving skills, aligned with FiftyOne’s contribution style
* Adds GitHub issue templates:
  * `new_skill.yml` for proposing new skills
  * `bug_report.yml` for structured bug reports
* Adds `.github/pull_request_template.md` with a skill-specific PR checklist
* Adds `.github/workflows/validate.yml` to run `validate-template.mjs` on every PR and push to `main`
* Updates the `README.md` Contributing section to point users to `CONTRIBUTING.md` and GitHub milestones