### PR TITLE
Add Skill for remote model integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -97,6 +97,12 @@
       "source": "./skills/fiftyone-eval-plugin",
       "skills": "./",
       "description": "Evaluates FiftyOne plugins for quality, security, and agent-readiness. Use when reviewing a plugin before installation, auditing an existing plugin, validating a plugin you just built, or assessing community plugins for safety. Checks manifest integrity, security risks (filesystem access, network calls, command execution, data exfiltration), schema quality, risk classification, code conventions, and agent discoverability. Produces a structured report with scores and actionable recommendations."
+    },
+    {
+      "name": "fiftyone-zoo-remote-model",
+      "source": "./skills/fiftyone-zoo-remote-model",
+      "skills": "./",
+      "description": "Integrate models into FiftyOne's remote model zoo. Use when wrapping a model (detection, classification, segmentation, embedding, keypoint, or vision-language) for `register_zoo_model_source` and `load_zoo_model` so it works with `dataset.apply_model`, debugging zoo registration, fixing `manifest.json` issues, building custom `fom.Model` / `TorchModelMixin` subclasses, or resolving DataLoader pickle errors and `ModuleNotFoundError` from spawned multi-worker DataLoader workers."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -132,6 +132,8 @@
       "name": "fiftyone-zoo-remote-model",
       "source": "./skills/fiftyone-zoo-remote-model",
       "skills": "./",
+      "emoji": "🧩",
+      "category": "Development",
       "description": "Integrate models into FiftyOne's remote model zoo. Use when wrapping a model (detection, classification, segmentation, embedding, keypoint, or vision-language) for `register_zoo_model_source` and `load_zoo_model` so it works with `dataset.apply_model`, debugging zoo registration, fixing `manifest.json` issues, building custom `fom.Model` / `TorchModelMixin` subclasses, or resolving DataLoader pickle errors and `ModuleNotFoundError` from spawned multi-worker DataLoader workers."
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,33 +161,27 @@ This repository contains skills for computer vision workflows using FiftyOne and
 
 ### FiftyOne Zoo Remote Model (`fiftyone-zoo-remote-model/`)
 
-**When to use:** User wants to integrate a model into FiftyOne's remote model zoo (detection, classification, segmentation, embedding, keypoint, or vision-language / VLM models loaded via `register_zoo_model_source` and `load_zoo_model`, then applied with `dataset.apply_model`). Also for debugging zoo registration, `manifest.json` issues, custom `fom.Model` / `TorchModelMixin` subclasses, DataLoader pickle errors, or `ModuleNotFoundError` from spawned DataLoader workers.
+**When to use:** User wants to integrate a model into FiftyOne's remote model zoo (detection, classification, segmentation, embedding, keypoint, or VLM), or debug zoo registration, manifest issues, or DataLoader pickle errors.
 
 **Instructions:** Load the skill file at `skills/fiftyone-zoo-remote-model/SKILL.md`
 
 **Key requirements:**
 - FiftyOne installed
-- Model framework dependencies (e.g., `torch`, `transformers`, `accelerate`)
-- Test on macOS with default `num_workers` to surface spawn-worker DataLoader bugs
+- Model framework (`torch`, `transformers`, etc.)
 
-**Workflow summary (4 phases):**
-1. Phase 0 — Confirm integration surface (zoo model vs plugin / operator / brain method)
-2. Phase 1 — Scaffold from `template/` (3-file structure: `manifest.json`, `__init__.py`, `zoo.py`)
-3. Phase 2 — Implement (class hierarchy, predict dispatch, label types, DataLoader; VLMs also load `VLM-PATTERNS.md`)
-4. Phase 3 — Validate (manifest `name`, relative imports, single `fo.Label` return, known-example coordinate check, multi-worker `apply_model` on macOS)
+**Workflow summary:**
+1. Phase 0 — Confirm integration surface
+2. Phase 1 — Scaffold from `template/`
+3. Phase 2 — Implement (class hierarchy, predict dispatch, label types, DataLoader)
+4. Phase 3 — Validate (manifest, imports, label return, multi-worker on macOS)
 
 **Reference files:**
-- `MANIFEST.md` — manifest schema and entry-point signatures
-- `MODEL-CLASS.md` — class hierarchy, properties, three-input predict dispatch
-- `DATALOADER.md` — worker pickle constraints, framework primitives, wrong fixes that look right
-- `LABEL-TYPES.md` — return types and coordinate normalization
-- `DEBUGGING-PRINCIPLES.md` — six universal principles with failure modes and diagnostic moves
-- `VLM-PATTERNS.md` — tool calling, generation budget, thinking, vision tokens, delimiters, multi-tier parser, coordinate quirks
-
-**Template files:**
-- `template/manifest.json` — minimal valid manifest skeleton
-- `template/__init__.py` — entry-point stubs aligned with FiftyOne SDK contract
-- `template/zoo.py` — config + model class skeleton (pickle-safe, no inference)
+- `MANIFEST.md` - Manifest schema and entry points
+- `MODEL-CLASS.md` - Class hierarchy and predict dispatch
+- `DATALOADER.md` - Worker pickle constraints
+- `LABEL-TYPES.md` - Return types and coordinates
+- `DEBUGGING-PRINCIPLES.md` - Six universal principles
+- `VLM-PATTERNS.md` - VLM-specific patterns
 
 ### FiftyOne Code Style (`fiftyone-code-style/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,36 @@ This repository contains skills for computer vision workflows using FiftyOne and
 - `PYTHON-PANEL.md` - Python panel development
 - `JAVASCRIPT-PANEL.md` - JavaScript/React panel development
 
+### FiftyOne Zoo Remote Model (`fiftyone-zoo-remote-model/`)
+
+**When to use:** User wants to integrate a model into FiftyOne's remote model zoo (detection, classification, segmentation, embedding, keypoint, or vision-language / VLM models loaded via `register_zoo_model_source` and `load_zoo_model`, then applied with `dataset.apply_model`). Also for debugging zoo registration, `manifest.json` issues, custom `fom.Model` / `TorchModelMixin` subclasses, DataLoader pickle errors, or `ModuleNotFoundError` from spawned DataLoader workers.
+
+**Instructions:** Load the skill file at `skills/fiftyone-zoo-remote-model/SKILL.md`
+
+**Key requirements:**
+- FiftyOne installed
+- Model framework dependencies (e.g., `torch`, `transformers`, `accelerate`)
+- Test on macOS with default `num_workers` to surface spawn-worker DataLoader bugs
+
+**Workflow summary (4 phases):**
+1. Phase 0 — Confirm integration surface (zoo model vs plugin / operator / brain method)
+2. Phase 1 — Scaffold from `template/` (3-file structure: `manifest.json`, `__init__.py`, `zoo.py`)
+3. Phase 2 — Implement (class hierarchy, predict dispatch, label types, DataLoader; VLMs also load `VLM-PATTERNS.md`)
+4. Phase 3 — Validate (manifest `name`, relative imports, single `fo.Label` return, known-example coordinate check, multi-worker `apply_model` on macOS)
+
+**Reference files:**
+- `MANIFEST.md` — manifest schema and entry-point signatures
+- `MODEL-CLASS.md` — class hierarchy, properties, three-input predict dispatch
+- `DATALOADER.md` — worker pickle constraints, framework primitives, wrong fixes that look right
+- `LABEL-TYPES.md` — return types and coordinate normalization
+- `DEBUGGING-PRINCIPLES.md` — six universal principles with failure modes and diagnostic moves
+- `VLM-PATTERNS.md` — tool calling, generation budget, thinking, vision tokens, delimiters, multi-tier parser, coordinate quirks
+
+**Template files:**
+- `template/manifest.json` — minimal valid manifest skeleton
+- `template/__init__.py` — entry-point stubs aligned with FiftyOne SDK contract
+- `template/zoo.py` — config + model class skeleton (pickle-safe, no inference)
+
 ### FiftyOne Code Style (`fiftyone-code-style/`)
 
 **When to use:** User wants to write Python code following FiftyOne conventions, contribute to FiftyOne, or ensure code matches FiftyOne's style.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Skills bridge the gap between natural language and FiftyOne's 80+ operators, pro
 | 🧹 [**Dataset Curation**](skills/fiftyone-dataset-curation/SKILL.md) | End-to-end curation: quality checks, annotation audit, duplicates, class distribution, splits | Yes |
 | 🔧 [**Troubleshoot**](skills/fiftyone-troubleshoot/SKILL.md) | Fix common issues: dataset persistence, App connection, MongoDB errors, codecs, performance | — |
 | 🛡️ [**Eval Plugin**](skills/fiftyone-eval-plugin/SKILL.md) | Evaluate plugins for quality, security, and agent-readiness. Produces a structured report | — |
+| 🧩 [**Zoo Remote Model**](skills/fiftyone-zoo-remote-model/SKILL.md) | Build remote model zoo integrations that work with `register_zoo_model_source` and `dataset.apply_model` | — |
 
 ## Quick Start
 

--- a/skills/fiftyone-zoo-remote-model/README.md
+++ b/skills/fiftyone-zoo-remote-model/README.md
@@ -1,0 +1,50 @@
+# Zoo Remote Model
+
+Build FiftyOne remote model zoo integrations that work with `register_zoo_model_source`, multi-worker DataLoader, and `dataset.apply_model`.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-zoo-remote-model** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- Python 3.9+
+- PyTorch (or the framework your model uses)
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"Build a remote zoo model wrapper for my Hugging Face detection model"
+"Create a FiftyOne zoo source with manifest.json for my custom classifier"
+"My zoo model raises ModuleNotFoundError from DataLoader workers — fix it"
+"Add VLM-style prompt dispatch to my zoo model"
+```
+
+The skill scaffolds the source layout (`manifest.json`, `__init__.py`, `zoo.py`), wires the model class against `TorchModelMixin` + `SupportsGetItem`, and walks the validation steps so the result works under multi-worker DataLoader and `dataset.apply_model`.
+
+## Example
+
+Register and apply a zoo source written with this skill:
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+foz.register_zoo_model_source("/path/to/your-zoo-source")
+model = foz.load_zoo_model("your-model-name")
+
+dataset = fo.load_dataset("your-dataset")
+dataset.apply_model(model, label_field="predictions")
+```
+
+## See also
+
+- [Remotely-sourced zoo models](https://docs.voxel51.com/model_zoo/remote.html)
+- [FiftyOne model zoo source](https://github.com/voxel51/fiftyone/tree/develop/fiftyone/zoo/models)

--- a/skills/fiftyone-zoo-remote-model/SKILL.md
+++ b/skills/fiftyone-zoo-remote-model/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: fiftyone-zoo-remote-model
+description: Build FiftyOne remote model zoo integrations that work with register_zoo_model_source, multi-worker DataLoader, and dataset.apply_model. Covers file structure, manifest, class hierarchy, DataLoader pickle compatibility, label return types, and common pitfalls.
+allowed-tools: Read, Grep, Glob, Agent, WebFetch, Write, Edit
+---
+
+# FiftyOne Remote Model Zoo — Integration Guide
+
+Use this skill when building a new FiftyOne model zoo integration intended for remote registration via `foz.register_zoo_model_source()`, or when debugging issues with an existing one.
+
+Reference documentation:
+- FiftyOne remote model zoo docs: https://docs.voxel51.com/model_zoo/remote.html
+- [MANIFEST.md](references/MANIFEST.md) — manifest.json format and `__init__.py` entry point
+- [MODEL-CLASS.md](references/MODEL-CLASS.md) — Config/Model class hierarchy, required properties, predict/predict_all
+- [DATALOADER.md](references/DATALOADER.md) — Multi-worker pickle compatibility, macOS restriction, platform-aware num_workers
+- [LABEL-TYPES.md](references/LABEL-TYPES.md) — Label return types, coordinate normalization
+
+## File Structure
+
+A remote model zoo source is a directory containing:
+
+```
+my-model/
+├── __init__.py       # Exports: download_model, load_model, resolve_input (all optional)
+├── zoo.py            # Model classes, configs, inference logic
+├── manifest.json     # Model metadata for zoo registration (REQUIRED)
+└── README.md         # Usage docs (optional)
+```
+
+See [references/MANIFEST.md](references/MANIFEST.md) for manifest.json format and `__init__.py` exports. See [MODEL-CLASS.md](references/MODEL-CLASS.md) for the zoo.py class hierarchy and predict/predict_all patterns.
+
+## Common Pitfalls
+
+1. **Missing `name` in manifest.json** — FiftyOne silently skips manifests without a top-level `name` field. The remote source registration appears to succeed but the model isn't found.
+
+2. **Custom picklable objects without platform-aware num_workers** — On macOS, custom classes from `zoo.py` in the DataLoader pickle cause `ModuleNotFoundError` in workers. Either use FiftyOne's built-in classes or gate `num_workers` on `sys.platform`. See [DATALOADER.md](references/DATALOADER.md).
+
+3. **Returning dicts from image predict_all** — Creates `label_field_key` prefixed fields instead of storing under `label_field` directly. Breaks nested field paths. See [LABEL-TYPES.md](references/LABEL-TYPES.md).
+
+4. **Wrong coordinate system** — VLMs often use non-standard coordinate orders or scales. Always verify the model's coordinate convention from concrete spatial examples in model documentation, not assumptions.
+
+5. **Model card vs library docs** — HuggingFace model cards may show incorrect API usage (wrong model class, etc.). Always verify against the library's official documentation.
+
+6. **Thinking mode + tool calling** — Models with thinking/reasoning modes may exhaust generation tokens before producing tool calls. Default to thinking OFF for structured operations.
+
+## Quick Checklist
+
+- [ ] `manifest.json` has top-level `name` field
+- [ ] `__init__.py` uses relative imports (`from .zoo import ...`)
+- [ ] Model inherits `fom.Model`, `fom.SamplesMixin`, `SupportsGetItem`, `TorchModelMixin`
+- [ ] `collate_fn` and `GetItem` use FiftyOne built-ins, OR custom classes with platform-aware `num_workers`
+- [ ] If using custom picklable objects, `num_workers=0` on macOS (`sys.platform == "darwin"`)
+- [ ] `predict_all` handles PIL Image, filepath string, and dict inputs
+- [ ] Image operations return single `fo.Label` instance, not dict
+- [ ] Coordinates normalized to `[0, 1]` range
+- [ ] Extra metadata stored as dynamic attributes on Labels

--- a/skills/fiftyone-zoo-remote-model/SKILL.md
+++ b/skills/fiftyone-zoo-remote-model/SKILL.md
@@ -44,7 +44,7 @@ Copy `template/`:
 - [ ] Image ops return single `fo.Label` (dicts only for video frame-level, integer keys).
 - [ ] One-known-example coordinate check passed.
 - [ ] `dataset.apply_model(model)` runs with default `num_workers`.
-- [ ] On macOS: no `ModuleNotFoundError` from workers.
+- [ ] On macOS, run `dataset.apply_model(model, ...)` with default `num_workers` and confirm no `ModuleNotFoundError` from spawned workers.
 
 **On failure**, route by symptom:
 

--- a/skills/fiftyone-zoo-remote-model/SKILL.md
+++ b/skills/fiftyone-zoo-remote-model/SKILL.md
@@ -46,7 +46,16 @@ Copy `template/`:
 - [ ] `dataset.apply_model(model)` runs with default `num_workers`.
 - [ ] On macOS: no `ModuleNotFoundError` from workers.
 
-On failure, see [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md).
+**On failure**, route by symptom:
+
+| Symptom | First look at |
+|---|---|
+| Registration "succeeds" but `load_zoo_model` fails | [MANIFEST.md](references/MANIFEST.md), [MODEL-CLASS.md](references/MODEL-CLASS.md) |
+| `ModuleNotFoundError` / pickle error from workers | [DATALOADER.md](references/DATALOADER.md) |
+| Predictions in unexpected fields or not stored | [LABEL-TYPES.md](references/LABEL-TYPES.md) |
+| Spatial outputs (boxes/points) in wrong location | [LABEL-TYPES.md](references/LABEL-TYPES.md); VLM: [VLM-PATTERNS.md](references/VLM-PATTERNS.md) |
+| Output is schema-correct but values are wrong | [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md) — *Schema compliance ≠ correctness* |
+| Backend / device error (OOM, op unimplemented) | [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md) — *Document upstream constraints* |
 
 ## Universal principles
 

--- a/skills/fiftyone-zoo-remote-model/SKILL.md
+++ b/skills/fiftyone-zoo-remote-model/SKILL.md
@@ -1,56 +1,67 @@
 ---
 name: fiftyone-zoo-remote-model
-description: Build FiftyOne remote model zoo integrations that work with register_zoo_model_source, multi-worker DataLoader, and dataset.apply_model. Covers file structure, manifest, class hierarchy, DataLoader pickle compatibility, label return types, and common pitfalls.
+description: Use when integrating a model into FiftyOne's remote model zoo — detection, classification, segmentation, embedding, keypoint, or vision-language (VLM) models loaded via `register_zoo_model_source` and `load_zoo_model`, then applied with `dataset.apply_model`. Also for debugging zoo registration, `manifest.json` issues, custom `fom.Model` / `TorchModelMixin` subclasses, DataLoader pickle errors, or worker `ModuleNotFoundError` from spawned DataLoader workers.
 allowed-tools: Read, Grep, Glob, Agent, WebFetch, Write, Edit
 ---
 
 # FiftyOne Remote Model Zoo — Integration Guide
 
-Use this skill when building a new FiftyOne model zoo integration intended for remote registration via `foz.register_zoo_model_source()`, or when debugging issues with an existing one.
+## When to use
 
-Reference documentation:
-- FiftyOne remote model zoo docs: https://docs.voxel51.com/model_zoo/remote.html
-- [MANIFEST.md](references/MANIFEST.md) — manifest.json format and `__init__.py` entry point
-- [MODEL-CLASS.md](references/MODEL-CLASS.md) — Config/Model class hierarchy, required properties, predict/predict_all
-- [DATALOADER.md](references/DATALOADER.md) — Multi-worker pickle compatibility, macOS restriction, platform-aware num_workers
-- [LABEL-TYPES.md](references/LABEL-TYPES.md) — Label return types, coordinate normalization
+Triggers: new remote zoo source; debugging an existing one; registration "succeeds" but model not loadable; `ModuleNotFoundError` from DataLoader workers; custom `fom.Model` / `TorchModelMixin`; VLM/structured-output integrations.
 
-## File Structure
+Not this skill: plugins, operators, panels, brain methods. Route via Phase 0.
 
-A remote model zoo source is a directory containing:
+## Phase 0 — Confirm the integration surface
 
-```
-my-model/
-├── __init__.py       # Exports: download_model, load_model, resolve_input (all optional)
-├── zoo.py            # Model classes, configs, inference logic
-├── manifest.json     # Model metadata for zoo registration (REQUIRED)
-└── README.md         # Usage docs (optional)
-```
+| User wants to… | Surface | Skill |
+|---|---|---|
+| Apply a model (`dataset.apply_model`) | Remote zoo model | this skill |
+| UI panels, buttons, side-effects | Plugin / operator | `fiftyone-develop-plugin` |
+| Embeddings, similarity, uniqueness | Brain method | brain docs |
 
-See [references/MANIFEST.md](references/MANIFEST.md) for manifest.json format and `__init__.py` exports. See [MODEL-CLASS.md](references/MODEL-CLASS.md) for the zoo.py class hierarchy and predict/predict_all patterns.
+**Required output**: one-line confirmation. Example: "Zoo model integration because user wants `dataset.apply_model(model)` to write predictions." If you cannot write that line, stop.
 
-## Common Pitfalls
+## Phase 1 — Scaffold
 
-1. **Missing `name` in manifest.json** — FiftyOne silently skips manifests without a top-level `name` field. The remote source registration appears to succeed but the model isn't found.
+Copy `template/`:
 
-2. **Custom picklable objects without platform-aware num_workers** — On macOS, custom classes from `zoo.py` in the DataLoader pickle cause `ModuleNotFoundError` in workers. Either use FiftyOne's built-in classes or gate `num_workers` on `sys.platform`. See [DATALOADER.md](references/DATALOADER.md).
+- `manifest.json` — top-level `name` required (silent skip if missing).
+- `__init__.py` — exports `download_model`, `load_model`, optional `resolve_input`. Relative imports: `from .zoo import ...`.
+- `zoo.py` — config + model class.
 
-3. **Returning dicts from image predict_all** — Creates `label_field_key` prefixed fields instead of storing under `label_field` directly. Breaks nested field paths. See [LABEL-TYPES.md](references/LABEL-TYPES.md).
+## Phase 2 — Implement
 
-4. **Wrong coordinate system** — VLMs often use non-standard coordinate orders or scales. Always verify the model's coordinate convention from concrete spatial examples in model documentation, not assumptions.
+- Class hierarchy, properties, three-input predict dispatch → [MODEL-CLASS.md](references/MODEL-CLASS.md).
+- Label return types, single-`fo.Label` rule, coordinates → [LABEL-TYPES.md](references/LABEL-TYPES.md).
+- DataLoader pickle, worker import resolution → [DATALOADER.md](references/DATALOADER.md).
+- **VLM / generative-structured-output** (uses `generate()` with prompts/schemas) → also [VLM-PATTERNS.md](references/VLM-PATTERNS.md).
 
-5. **Model card vs library docs** — HuggingFace model cards may show incorrect API usage (wrong model class, etc.). Always verify against the library's official documentation.
+## Phase 3 — Validate
 
-6. **Thinking mode + tool calling** — Models with thinking/reasoning modes may exhaust generation tokens before producing tool calls. Default to thinking OFF for structured operations.
+- [ ] `manifest.json` has top-level `name`.
+- [ ] `__init__.py` uses relative imports.
+- [ ] Image ops return single `fo.Label` (dicts only for video frame-level, integer keys).
+- [ ] One-known-example coordinate check passed.
+- [ ] `dataset.apply_model(model)` runs with default `num_workers`.
+- [ ] On macOS: no `ModuleNotFoundError` from workers.
 
-## Quick Checklist
+On failure, see [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md).
 
-- [ ] `manifest.json` has top-level `name` field
-- [ ] `__init__.py` uses relative imports (`from .zoo import ...`)
-- [ ] Model inherits `fom.Model`, `fom.SamplesMixin`, `SupportsGetItem`, `TorchModelMixin`
-- [ ] `collate_fn` and `GetItem` use FiftyOne built-ins, OR custom classes with platform-aware `num_workers`
-- [ ] If using custom picklable objects, `num_workers=0` on macOS (`sys.platform == "darwin"`)
-- [ ] `predict_all` handles PIL Image, filepath string, and dict inputs
-- [ ] Image operations return single `fo.Label` instance, not dict
-- [ ] Coordinates normalized to `[0, 1]` range
-- [ ] Extra metadata stored as dynamic attributes on Labels
+## Universal principles
+
+- **Framework-first.** Use FiftyOne's existing classes before defining your own. Why: framework classes resolve to importable modules; replacements re-introduce solved problems.
+- **Worker-pickle constraint.** Objects pickled across a DataLoader worker boundary must resolve to a module the worker can import. Why: remote zoo sources load via `importlib.util.spec_from_file_location` and are not on `sys.path` of spawned workers.
+- **Reference implementations need verification.** A pattern copied from another zoo source is not guaranteed correct. Why: at least one widely-copied VLM reference silently breaks under multi-worker.
+- **Schema compliance ≠ correctness.** A schema-conforming model is not necessarily producing correct values. Why: schema-following models echo your wrong field names back at you.
+- **Read specs, don't patch parsers.** When a parser keeps breaking, find the format spec before iterating. Why: each patch shifts the failure to a different malformation; the cycle is unbounded.
+- **Bounded repair scope.** Repair the few common malformations and stop. Why: unbounded repair masks model-quality regressions.
+
+## Quick reference index
+
+- [MANIFEST.md](references/MANIFEST.md) — schema, entry points, idempotent `download_model`.
+- [MODEL-CLASS.md](references/MODEL-CLASS.md) — hierarchy, properties, predict dispatch.
+- [DATALOADER.md](references/DATALOADER.md) — worker pickle WHY, primitives, wrong fixes that look right.
+- [LABEL-TYPES.md](references/LABEL-TYPES.md) — return types, coordinate normalization.
+- [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md) — six rules with failure modes and diagnostic moves.
+- [VLM-PATTERNS.md](references/VLM-PATTERNS.md) — tool calling, generation budget, thinking, vision tokens, delimiters, multi-tier parser, coordinate quirks.

--- a/skills/fiftyone-zoo-remote-model/SKILL.md
+++ b/skills/fiftyone-zoo-remote-model/SKILL.md
@@ -57,14 +57,16 @@ Copy `template/`:
 | Output is schema-correct but values are wrong | [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md) — *Schema compliance ≠ correctness* |
 | Backend / device error (OOM, op unimplemented) | [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md) — *Document upstream constraints* |
 
-## Universal principles
+## Key Directives
 
-- **Framework-first.** Use FiftyOne's existing classes before defining your own. Why: framework classes resolve to importable modules; replacements re-introduce solved problems.
-- **Worker-pickle constraint.** Objects pickled across a DataLoader worker boundary must resolve to a module the worker can import. Why: remote zoo sources load via `importlib.util.spec_from_file_location` and are not on `sys.path` of spawned workers.
-- **Reference implementations need verification.** A pattern copied from another zoo source is not guaranteed correct. Why: at least one widely-copied VLM reference silently breaks under multi-worker.
-- **Schema compliance ≠ correctness.** A schema-conforming model is not necessarily producing correct values. Why: schema-following models echo your wrong field names back at you.
-- **Read specs, don't patch parsers.** When a parser keeps breaking, find the format spec before iterating. Why: each patch shifts the failure to a different malformation; the cycle is unbounded.
-- **Bounded repair scope.** Repair the few common malformations and stop. Why: unbounded repair masks model-quality regressions.
+Canonical names; other files cite by name. Full failure modes and diagnostic moves in [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md).
+
+- **Framework-first.** ALWAYS use FiftyOne primitives before custom code. *Why:* framework classes are worker-importable; yours aren't.
+- **Worker-pickle constraint.** NEVER define pickle-bound objects in `zoo.py`. *Why:* spawned DataLoader workers can't import modules loaded via `importlib.util.spec_from_file_location`.
+- **Reference implementations need verification.** NEVER copy a pattern from another zoo source without running it under multi-worker first. *Why:* widely-copied references silently break.
+- **Schema compliance ≠ correctness.** NEVER trust schema-conformant outputs as proof of correctness. *Why:* models echo your wrong field names back unchanged.
+- **Read specs, don't patch parsers.** NEVER patch a parser more than twice — find the format spec. *Why:* each patch shifts the failure elsewhere; the cycle is unbounded.
+- **Bounded repair scope.** NEVER grow repair logic past a few common malformations. *Why:* unbounded repair masks model-quality regressions.
 
 ## Quick reference index
 

--- a/skills/fiftyone-zoo-remote-model/SKILL.md
+++ b/skills/fiftyone-zoo-remote-model/SKILL.md
@@ -31,7 +31,7 @@ Copy `template/`:
 
 ## Phase 2 — Implement
 
-- Class hierarchy, properties, three-input predict dispatch → [MODEL-CLASS.md](references/MODEL-CLASS.md).
+- Class hierarchy, properties, predict/predict_all input dispatch → [MODEL-CLASS.md](references/MODEL-CLASS.md).
 - Label return types, single-`fo.Label` rule, coordinates → [LABEL-TYPES.md](references/LABEL-TYPES.md).
 - DataLoader pickle, worker import resolution → [DATALOADER.md](references/DATALOADER.md).
 - **VLM / generative-structured-output** (uses `generate()` with prompts/schemas) → also [VLM-PATTERNS.md](references/VLM-PATTERNS.md).

--- a/skills/fiftyone-zoo-remote-model/SKILL.md
+++ b/skills/fiftyone-zoo-remote-model/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: fiftyone-zoo-remote-model
 description: Use when integrating a model into FiftyOne's remote model zoo — detection, classification, segmentation, embedding, keypoint, or vision-language (VLM) models loaded via `register_zoo_model_source` and `load_zoo_model`, then applied with `dataset.apply_model`. Also for debugging zoo registration, `manifest.json` issues, custom `fom.Model` / `TorchModelMixin` subclasses, DataLoader pickle errors, or worker `ModuleNotFoundError` from spawned DataLoader workers.
-allowed-tools: Read, Grep, Glob, Agent, WebFetch, Write, Edit
 ---
 
 # FiftyOne Remote Model Zoo — Integration Guide

--- a/skills/fiftyone-zoo-remote-model/references/DATALOADER.md
+++ b/skills/fiftyone-zoo-remote-model/references/DATALOADER.md
@@ -1,0 +1,95 @@
+# DataLoader Multi-Worker Pickle Compatibility
+
+FiftyOne's `dataset.apply_model()` uses a PyTorch DataLoader with `num_workers > 0` for models that inherit `SupportsGetItem` or `TorchModelMixin`. Two objects are pickled for workers: the `collate_fn` and the `GetItem` from `build_get_item()`.
+
+## macOS Pickle Restriction
+
+On macOS, DataLoader workers use `spawn` by default. FiftyOne loads remote zoo sources via `importlib.util.spec_from_file_location`, registering the module in the parent's `sys.modules` only. Spawned workers on macOS CANNOT import the zoo source module, so **custom classes defined in `zoo.py` will cause `ModuleNotFoundError` when pickled for workers on macOS.**
+
+On Linux and Windows, `fork`-based workers inherit the parent's `sys.modules`, so custom `collate_fn` and `GetItem` subclasses defined in `zoo.py` work normally with `num_workers > 0`.
+
+## Platform-Aware num_workers
+
+To support custom picklable objects cross-platform, gate `num_workers` on the platform:
+
+```python
+import sys
+
+num_workers = user_provided_num_workers  # or the default
+dataset.apply_model(
+    model,
+    label_field="predictions",
+    num_workers=num_workers if sys.platform != "darwin" else 0,
+)
+```
+
+Setting `num_workers=0` on macOS runs inference in the main process, avoiding the pickle issue entirely while still allowing custom `GetItem` and `collate_fn` on other platforms.
+
+## Option A: Use FiftyOne Built-ins (works everywhere)
+
+If you don't need custom picklable objects, use FiftyOne's own classes. This approach works on all platforms with any `num_workers` value.
+
+### collate_fn — Inherit, Don't Override
+
+`TorchModelMixin` provides `collate_fn` as a `@staticmethod` that returns `batch` as-is. It's defined in `fiftyone.core.models` — always importable by workers.
+
+```python
+# Inherit from TorchModelMixin — works on all platforms
+@property
+def has_collate_fn(self) -> bool:
+    return True
+# collate_fn is inherited — do NOT define it
+```
+
+### GetItem — Use FiftyOne's ImageGetItem
+
+`fiftyone.utils.torch.ImageGetItem` is a concrete `GetItem` subclass that loads images from filepaths. With `raw_inputs=True`, it returns PIL Images directly. Workers can always import it.
+
+```python
+# Uses fiftyone's class — works on all platforms
+def build_get_item(self, field_mapping=None) -> ImageGetItem:
+    return ImageGetItem(field_mapping=field_mapping, raw_inputs=True)
+```
+
+## Option B: Custom Classes (requires platform-aware num_workers)
+
+Custom `collate_fn` and `GetItem` subclasses defined in `zoo.py` are viable when paired with the platform-aware `num_workers` pattern above. On macOS, `num_workers=0` avoids pickling entirely; on other platforms, workers can import the module normally.
+
+```python
+# Custom collate_fn — works on Linux/Windows with workers, macOS with num_workers=0
+def _my_collate(batch):
+    # custom batching logic
+    return batch
+
+@property
+def collate_fn(self):
+    return _my_collate
+
+# Custom GetItem — works on Linux/Windows with workers, macOS with num_workers=0
+class MyGetItem(GetItem):
+    def __call__(self, d):
+        return {"filepath": d["filepath"]}
+
+def build_get_item(self, field_mapping=None):
+    return MyGetItem(field_mapping=field_mapping)
+```
+
+**Important:** If using custom classes, you MUST use the platform-aware `num_workers` pattern in your `apply_model()` call, or macOS users will hit `ModuleNotFoundError`.
+
+## How FiftyOne Dispatches apply_model
+
+```
+apply_model(model, ...)
+│
+├─ isinstance(model, (SupportsGetItem, TorchModelMixin))?
+│  YES → _apply_image_model_data_loader()   ← multi-worker DataLoader path
+│  │     Creates DataLoader with num_workers, pickles GetItem + collate_fn
+│  │     Calls model.predict_all(batch, samples=sample_batch)
+│  │
+│  NO, batch_size provided?
+│     YES → _apply_image_model_batch()      ← batch path, no DataLoader
+│     │     Calls model.predict_all([filepaths], samples=batch)
+│     │
+│     NO → _apply_image_model_single()       ← simple path
+│          Calls model.predict(filepath, sample=sample) per sample
+```

--- a/skills/fiftyone-zoo-remote-model/references/DATALOADER.md
+++ b/skills/fiftyone-zoo-remote-model/references/DATALOADER.md
@@ -1,95 +1,70 @@
 # DataLoader Multi-Worker Pickle Compatibility
 
-FiftyOne's `dataset.apply_model()` uses a PyTorch DataLoader with `num_workers > 0` for models that inherit `SupportsGetItem` or `TorchModelMixin`. Two objects are pickled for workers: the `collate_fn` and the `GetItem` from `build_get_item()`.
+`dataset.apply_model()` runs a PyTorch DataLoader for any model inheriting `SupportsGetItem` or `TorchModelMixin`. The `collate_fn` and the `GetItem` instance are pickled across the worker boundary. If either resolves to a module the worker cannot import, you get `ModuleNotFoundError` from the spawned worker.
 
-## macOS Pickle Restriction
+## 1. Why workers can't import your module
 
-On macOS, DataLoader workers use `spawn` by default. FiftyOne loads remote zoo sources via `importlib.util.spec_from_file_location`, registering the module in the parent's `sys.modules` only. Spawned workers on macOS CANNOT import the zoo source module, so **custom classes defined in `zoo.py` will cause `ModuleNotFoundError` when pickled for workers on macOS.**
+FiftyOne loads remote zoo sources via `importlib.util.spec_from_file_location`. The module is registered in the **parent's** `sys.modules`, but its directory is **never** added to `sys.path`.
 
-On Linux and Windows, `fork`-based workers inherit the parent's `sys.modules`, so custom `collate_fn` and `GetItem` subclasses defined in `zoo.py` work normally with `num_workers > 0`.
+| Platform | Worker start | Result |
+|---|---|---|
+| macOS | `spawn` (default) | Fresh interpreter; no inherited `sys.modules`; cannot import zoo source. |
+| Linux, Python 3.14+ POSIX | `spawn`/`forkserver` | Same as macOS. |
+| Linux (current default) | `fork` | Inherits parent `sys.modules`; **silently masks the bug**. |
 
-## Platform-Aware num_workers
+A zoo source that "works on Linux" can fail on macOS or after a Python version bump. Concrete signature:
 
-To support custom picklable objects cross-platform, gate `num_workers` on the platform:
-
-```python
-import sys
-
-num_workers = user_provided_num_workers  # or the default
-dataset.apply_model(
-    model,
-    label_field="predictions",
-    num_workers=num_workers if sys.platform != "darwin" else 0,
-)
+```
+ModuleNotFoundError: No module named 'fiftyone.zoo.models.<your-source>'
 ```
 
-Setting `num_workers=0` on macOS runs inference in the main process, avoiding the pickle issue entirely while still allowing custom `GetItem` and `collate_fn` on other platforms.
+## 2. The pickle-resolution rule
 
-## Option A: Use FiftyOne Built-ins (works everywhere)
+Pickle serializes objects by **qualified module path**, not by value. If a `collate_fn`, `GetItem`, or any closure is defined in your `zoo.py`, pickle stores `your_zoo_source.SomeClass`. The worker `import`s that path, fails, and dies before your code runs.
 
-If you don't need custom picklable objects, use FiftyOne's own classes. This approach works on all platforms with any `num_workers` value.
+Principle: **Worker-pickle constraint** — anything crossing the worker boundary must resolve to a module the worker can import.
 
-### collate_fn — Inherit, Don't Override
+## 3. The right answer
 
-`TorchModelMixin` provides `collate_fn` as a `@staticmethod` that returns `batch` as-is. It's defined in `fiftyone.core.models` — always importable by workers.
+Use what the framework already provides. Both pickle to modules workers can always import.
+
+| Need | Use | Pickles to |
+|---|---|---|
+| Collate | `TorchModelMixin.collate_fn` (inherit, don't override) | `fiftyone.core.models` |
+| Per-sample loading | `fiftyone.utils.torch.ImageGetItem(raw_inputs=True)` | `fiftyone.utils.torch` |
 
 ```python
-# Inherit from TorchModelMixin — works on all platforms
+from fiftyone.utils.torch import ImageGetItem
+
 @property
 def has_collate_fn(self) -> bool:
-    return True
-# collate_fn is inherited — do NOT define it
-```
+    return True   # framework-first: inherit collate_fn from TorchModelMixin
 
-### GetItem — Use FiftyOne's ImageGetItem
-
-`fiftyone.utils.torch.ImageGetItem` is a concrete `GetItem` subclass that loads images from filepaths. With `raw_inputs=True`, it returns PIL Images directly. Workers can always import it.
-
-```python
-# Uses fiftyone's class — works on all platforms
 def build_get_item(self, field_mapping=None) -> ImageGetItem:
     return ImageGetItem(field_mapping=field_mapping, raw_inputs=True)
 ```
 
-## Option B: Custom Classes (requires platform-aware num_workers)
+Principle: **Framework-first** — use FiftyOne's existing classes before defining your own.
 
-Custom `collate_fn` and `GetItem` subclasses defined in `zoo.py` are viable when paired with the platform-aware `num_workers` pattern above. On macOS, `num_workers=0` avoids pickling entirely; on other platforms, workers can import the module normally.
+## 4. Why `num_workers=0` is not the fix
 
-```python
-# Custom collate_fn — works on Linux/Windows with workers, macOS with num_workers=0
-def _my_collate(batch):
-    # custom batching logic
-    return batch
+It removes worker pickling entirely. Multi-worker is **non-negotiable**: production-scale datasets require it for I/O parallelism. A zoo source that requires `num_workers=0` is broken, not "tradeoff-configured." Validate with default `num_workers` on macOS before shipping.
 
-@property
-def collate_fn(self):
-    return _my_collate
+## 5. Why reference implementations may be wrong
 
-# Custom GetItem — works on Linux/Windows with workers, macOS with num_workers=0
-class MyGetItem(GetItem):
-    def __call__(self, d):
-        return {"filepath": d["filepath"]}
+Several widely-copied remote zoo sources define nested-closure collate functions or custom `GetItem` subclasses inline in `zoo.py`. They run on Linux fork-workers and silently break on macOS spawn-workers. Copying them propagates the bug.
 
-def build_get_item(self, field_mapping=None):
-    return MyGetItem(field_mapping=field_mapping)
-```
+Verification: run `dataset.apply_model(model)` with **default** `num_workers` on macOS before treating any reference as a template.
 
-**Important:** If using custom classes, you MUST use the platform-aware `num_workers` pattern in your `apply_model()` call, or macOS users will hit `ModuleNotFoundError`.
+Principle: **Reference implementations need verification.**
 
-## How FiftyOne Dispatches apply_model
+## 6. Wrong fixes that look right
 
-```
-apply_model(model, ...)
-│
-├─ isinstance(model, (SupportsGetItem, TorchModelMixin))?
-│  YES → _apply_image_model_data_loader()   ← multi-worker DataLoader path
-│  │     Creates DataLoader with num_workers, pickles GetItem + collate_fn
-│  │     Calls model.predict_all(batch, samples=sample_batch)
-│  │
-│  NO, batch_size provided?
-│     YES → _apply_image_model_batch()      ← batch path, no DataLoader
-│     │     Calls model.predict_all([filepaths], samples=batch)
-│     │
-│     NO → _apply_image_model_single()       ← simple path
-│          Calls model.predict(filepath, sample=sample) per sample
-```
+Preserved so the next agent does not re-walk the journey.
+
+- **Module-level helper with `__module__` reassigned to your zoo source** — workers still cannot import your zoo source.
+- **Nested closure inside a property** — closures are unpicklable; raises `PicklingError` immediately.
+- **Custom `__reduce__` returning a string-encoded `lambda`** — fragile, opaque, and breaks again on the next pickle protocol.
+- **`PYTHONPATH` injection from `__init__.py`** — mutates global interpreter state on import; affects unrelated code; still racy with already-spawned workers.
+
+The only correct fix is Section 3.

--- a/skills/fiftyone-zoo-remote-model/references/DEBUGGING-PRINCIPLES.md
+++ b/skills/fiftyone-zoo-remote-model/references/DEBUGGING-PRINCIPLES.md
@@ -1,0 +1,59 @@
+# Debugging Principles
+
+Six universal principles for remote zoo model integration. Each rule has a canonical name; other files cite them by that name.
+
+## 1. Framework-first
+
+**Rule.** Use FiftyOne's existing classes before defining your own.
+
+**Failure mode.** Writing custom `collate_fn` and `GetItem` from scratch, then debugging pickle errors that the framework's classes do not have.
+
+**Diagnostic move.** Before writing a class, search FiftyOne for an existing one with the same shape (`TorchModelMixin.collate_fn`, `fiftyone.utils.torch.ImageGetItem`).
+
+## 2. Worker-pickle constraint
+
+**Rule.** Anything pickled across a DataLoader worker boundary must resolve to a module the worker can import.
+
+**Failure mode.** Code works locally with `num_workers=0`, fails in CI or on user machines with `ModuleNotFoundError` from spawned workers.
+
+**Diagnostic move.** Run `apply_model` with default `num_workers` on macOS as a smoke test before shipping.
+
+## 3. Reference implementations need verification
+
+**Rule.** A pattern copied from another zoo source is not guaranteed correct.
+
+**Failure mode.** Copying a pattern from a popular remote zoo source that itself does not support multi-worker.
+
+**Diagnostic move.** Run multi-worker on the reference before copying its structure.
+
+## 4. Schema compliance ≠ correctness
+
+**Rule.** A model that conforms to your tool/JSON schema is not necessarily producing correct values.
+
+**Failure mode.** Tool/JSON schema includes a field name the model has never seen; the model echoes it back; output looks correct but values are mis-mapped (e.g., bbox order silently swapped).
+
+**Diagnostic move.** Verify outputs against ground-truth examples where the answer is known by inspection, not against schema validators.
+
+## 5. Read specs, don't patch parsers
+
+**Rule.** When a parser keeps breaking, find the format specification before iterating.
+
+**Failure mode.** Regex after regex to handle "double commas", "unquoted keys", "fused quote patterns" — each fix shifts the failure.
+
+**Diagnostic move.** When the second parser patch fails, stop. Find the format spec from upstream (transformers, vLLM, the model author's repo). 30 minutes spent reading saves a day of patching.
+
+## 6. Bounded repair scope
+
+**Rule.** Repair the few common malformations and stop.
+
+**Failure mode.** Parsing-repair logic grows unboundedly to handle every observed malformation, masking real model-quality regressions.
+
+**Diagnostic move.** Define the four most common malformations once. Beyond those, return empty rather than repair.
+
+## Diagnostic discipline
+
+- **Isolate variables when multiple things look broken.** Build a 2x2x... diagnostic that varies one factor at a time (e.g., thinking on/off x tools/no-tools x schema-A/schema-B). The discipline turns "parsing is broken" into n independent root causes.
+
+- **Trust library docs over model cards.** Wrong-but-loadable model classes (`AutoModelFor*` mismatches) produce subtly wrong output without raising errors. When card and library disagree, the library is higher fidelity.
+
+- **Document upstream constraints; don't work around them.** Some failures are framework / backend gaps (e.g., specific ops unimplemented on MPS). Surface in manifest `requirements` or README; do not write workaround code.

--- a/skills/fiftyone-zoo-remote-model/references/LABEL-TYPES.md
+++ b/skills/fiftyone-zoo-remote-model/references/LABEL-TYPES.md
@@ -1,0 +1,148 @@
+# Model Predicition Label Return Types
+
+### Image Operations
+
+**Image models must return a single `fo.Label` instance per sample — NOT a dict.**
+
+| Operation | Return Type | Example |
+|-----------|-------------|---------|
+| VQA / Caption / OCR | `fo.Classification` | `fo.Classification(label="A dog on a beach")` |
+| Single classification | `fo.Classification` | `fo.Classification(label="cat")` |
+| Multi-label classification | `fo.Classifications` | `fo.Classifications(classifications=[fo.Classification(label="outdoor"), ...])` |
+| Tagging | `fo.Classifications` | Same as multi-label classification |
+| Object detection | `fo.Detections` | `fo.Detections(detections=[fo.Detection(label="car", bounding_box=[x,y,w,h]), ...])` |
+| Keypoint detection | `fo.Keypoints` | `fo.Keypoints(keypoints=[fo.Keypoint(label="face", points=[[x,y]]), ...])` |
+| Instance segmentation | `fo.Detections` | `fo.Detections(detections=[fo.Detection(label="cat", mask=mask_array), ...])` |
+| Semantic segmentation | `fo.Segmentation` | `fo.Segmentation(mask=mask_array)` |
+
+**Key details:**
+- Bounding boxes use `[x, y, width, height]` in `[0, 1]` normalized coordinates
+- Keypoints use `[[x, y], ...]` in `[0, 1]` normalized coordinates
+- Text responses (VQA, caption, OCR) are wrapped in `fo.Classification(label=text)` — do NOT return raw strings
+
+### Video Operations (frame-level)
+
+Video models may return a **dict** from `predict_all()`, but ONLY when the dict uses **integer frame numbers** as keys. FiftyOne's `add_labels` detects this and merges into `sample.frames`.
+
+```python
+# Sample-level labels (simple string/label) — return single Label or dict with string keys
+{"summary": "A person walks across a park"}
+
+# Frame-level labels — dict with integer keys
+{
+    1: {"objects": fo.Detections(detections=[...])},
+    15: {"objects": fo.Detections(detections=[...])},
+}
+
+# Mixed sample + frame-level — dict with both string and integer keys
+{
+    "summary": "A person walks across a park",
+    1: {"objects": fo.Detections(detections=[...])},
+}
+```
+
+Video-specific label types:
+- `fo.TemporalDetection` / `fo.TemporalDetections` — time-range events on the full video
+- Frame-level `fo.Detections` — per-frame bounding boxes (stored in `sample.frames[N]`)
+
+## Storing Metadata as Dynamic Attributes
+
+Do NOT create wrapper dicts to store extra data alongside labels. Instead, use **dynamic attributes** on the Label instance itself:
+
+```python
+# WRONG — returns a dict, breaks nested label_field
+def _parse_output(self, text, reasoning):
+    return {"detections": fo.Detections(...), "raw": text, "reasoning": reasoning}
+
+# CORRECT — returns single Label, metadata as dynamic attributes
+def _parse_output(self, text, reasoning):
+    dets = fo.Detections(detections=[...])
+    if reasoning:
+        for det in dets.detections:
+            det["reasoning"] = reasoning
+    return dets
+```
+
+Dynamic attributes can be set on any Label subclass:
+```python
+label = fo.Classification(label="cat")
+label["confidence_raw"] = 0.95
+label["reasoning"] = "The image shows pointed ears and whiskers..."
+label["model_name"] = "gemma-4-E4B-it"
+```
+
+Users access them via:
+```python
+sample.predictions["reasoning"]       # on Classification
+sample.predictions.detections[0]["reasoning"]  # on individual Detection
+```
+
+## How FiftyOne's add_labels Works
+
+Understanding the dispatch logic in `Sample.add_labels()`:
+
+```python
+labels = model.predict(img)
+
+if isinstance(labels, dict):
+    if all keys are integers:
+        → Frame-level labels: merge into sample.frames
+    elif any key is an integer:
+        → Mixed: string keys become sample fields, int keys become frame fields
+    else:
+        → Multiple sample fields: each key maps to label_field + "_" + key
+elif labels is a Label instance:
+    → Single field: stored directly in label_field
+```
+
+The `label_field` key mapping for dicts:
+```python
+# When label_field is a string (e.g., "predictions"):
+key_fn = lambda k: "predictions_" + k
+# {"detections": ..., "raw": ...} → sample.predictions_detections, sample.predictions_raw
+
+# When label_field is a dict:
+key_fn = lambda k: label_field.get(k, k)
+# label_field={"detections": "preds"} → sample.preds
+
+# When label_field is None:
+key_fn = lambda k: k
+# {"detections": ...} → sample.detections
+```
+
+## Coordinate Normalization
+
+FiftyOne uses `[0, 1]` normalized coordinates for all spatial labels:
+
+- **Bounding boxes**: `[x, y, width, height]` where `(x, y)` is top-left corner
+- **Keypoints**: `[[x, y], ...]`
+- **Polylines**: `[[[x, y], ...], ...]`
+
+If a model outputs coordinates in pixel space or 0-1000 scale, normalize before creating labels:
+```python
+# From 0-1000 scale (common in VLMs like Gemma4, Qwen3.5)
+x1, y1, x2, y2 = raw_bbox
+fo.Detection(
+    label=label,
+    bounding_box=[x1/1000, y1/1000, (x2-x1)/1000, (y2-y1)/1000],
+)
+
+# From pixel coordinates
+fo.Detection(
+    label=label,
+    bounding_box=[x/img_w, y/img_h, w/img_w, h/img_h],
+)
+```
+
+## Quick Checklist
+
+When implementing `predict()` / `predict_all()` for a FiftyOne zoo model:
+
+- [ ] Image operations return a single `fo.Label` subclass, not a dict
+- [ ] Text outputs (VQA, caption, OCR) wrapped in `fo.Classification(label=text)`
+- [ ] Detection boxes are `[x, y, w, h]` in `[0, 1]` range
+- [ ] Keypoints are `[[x, y], ...]` in `[0, 1]` range
+- [ ] Extra metadata stored as dynamic attributes on the Label, not in wrapper dicts
+- [ ] Video frame-level results use integer keys in the return dict
+- [ ] `collate_fn` inherited from `TorchModelMixin` (not overridden) — see `/fiftyone-zoo-remote-model` skill for details
+- [ ] `build_get_item` returns `ImageGetItem(raw_inputs=True)` — no custom `GetItem` subclass in zoo module

--- a/skills/fiftyone-zoo-remote-model/references/LABEL-TYPES.md
+++ b/skills/fiftyone-zoo-remote-model/references/LABEL-TYPES.md
@@ -16,99 +16,62 @@
 | Semantic segmentation | `fo.Segmentation` | `fo.Segmentation(mask=mask_array)` |
 
 **Key details:**
-- Bounding boxes use `[x, y, width, height]` in `[0, 1]` normalized coordinates
-- Keypoints use `[[x, y], ...]` in `[0, 1]` normalized coordinates
-- Text responses (VQA, caption, OCR) are wrapped in `fo.Classification(label=text)` — do NOT return raw strings
+- Bounding boxes: `[x, y, width, height]` in `[0, 1]`; keypoints: `[[x, y], ...]` in `[0, 1]`
+- Text responses (VQA, caption, OCR) wrapped in `fo.Classification(label=text)` — do NOT return raw strings
 
 ### Video Operations (frame-level)
 
 Video models may return a **dict** from `predict_all()`, but ONLY when the dict uses **integer frame numbers** as keys. FiftyOne's `add_labels` detects this and merges into `sample.frames`.
 
 ```python
-# Sample-level labels (simple string/label) — return single Label or dict with string keys
-{"summary": "A person walks across a park"}
+# Frame-level — dict with integer keys
+{1: {"objects": fo.Detections(...)}, 15: {"objects": fo.Detections(...)}}
 
-# Frame-level labels — dict with integer keys
-{
-    1: {"objects": fo.Detections(detections=[...])},
-    15: {"objects": fo.Detections(detections=[...])},
-}
-
-# Mixed sample + frame-level — dict with both string and integer keys
-{
-    "summary": "A person walks across a park",
-    1: {"objects": fo.Detections(detections=[...])},
-}
+# Mixed sample + frame-level — string and integer keys
+{"summary": "A person walks", 1: {"objects": fo.Detections(...)}}
 ```
 
-Video-specific label types:
-- `fo.TemporalDetection` / `fo.TemporalDetections` — time-range events on the full video
-- Frame-level `fo.Detections` — per-frame bounding boxes (stored in `sample.frames[N]`)
+Video-specific types: `fo.TemporalDetection` / `fo.TemporalDetections` (time-range events); frame-level `fo.Detections` (stored in `sample.frames[N]`).
 
 ## Storing Metadata as Dynamic Attributes
 
-Do NOT create wrapper dicts to store extra data alongside labels. Instead, use **dynamic attributes** on the Label instance itself:
+Do NOT wrap labels in a dict. Use **dynamic attributes** on the Label itself:
 
 ```python
-# WRONG — returns a dict, breaks nested label_field
+# WRONG — dict return triggers silent field-splitting (see below)
 def _parse_output(self, text, reasoning):
-    return {"detections": fo.Detections(...), "raw": text, "reasoning": reasoning}
+    return {"label": "cat", "reasoning": reasoning}
 
-# CORRECT — returns single Label, metadata as dynamic attributes
+# CORRECT — single Label with dynamic attribute
 def _parse_output(self, text, reasoning):
-    dets = fo.Detections(detections=[...])
-    if reasoning:
-        for det in dets.detections:
-            det["reasoning"] = reasoning
-    return dets
+    cls = fo.Classification(label="cat")
+    cls["reasoning"] = reasoning
+    return cls
 ```
 
-Dynamic attributes can be set on any Label subclass:
-```python
-label = fo.Classification(label="cat")
-label["confidence_raw"] = 0.95
-label["reasoning"] = "The image shows pointed ears and whiskers..."
-label["model_name"] = "gemma-4-E4B-it"
+### The silent `predictions_<key>` failure
+
+If the model returns `{"label": "cat", "reasoning": "..."}` and the user calls `dataset.apply_model(model, label_field="predictions")`, FiftyOne does NOT raise. It silently splits the dict into top-level fields:
+
+```
+sample.predictions_label       # fo.Classification(label="cat")
+sample.predictions_reasoning   # "..." (string field)
 ```
 
-Users access them via:
-```python
-sample.predictions["reasoning"]       # on Classification
-sample.predictions.detections[0]["reasoning"]  # on individual Detection
-```
+There is no `sample.predictions` field. Downstream `sample.predictions.label` fails with `AttributeError` — `predictions` is a Classification at `predictions_label`, not at `predictions`. Grep signature: `predictions_<key>`. Fix: return a single Label with `label["reasoning"] = ...`.
 
-## How FiftyOne's add_labels Works
+Users access dynamic attributes via `sample.predictions["reasoning"]` or `sample.predictions.detections[0]["reasoning"]`.
 
-Understanding the dispatch logic in `Sample.add_labels()`:
+## `add_labels` Dispatch (reference)
 
-```python
-labels = model.predict(img)
+`Sample.add_labels()` branches on the return value:
 
-if isinstance(labels, dict):
-    if all keys are integers:
-        → Frame-level labels: merge into sample.frames
-    elif any key is an integer:
-        → Mixed: string keys become sample fields, int keys become frame fields
-    else:
-        → Multiple sample fields: each key maps to label_field + "_" + key
-elif labels is a Label instance:
-    → Single field: stored directly in label_field
-```
-
-The `label_field` key mapping for dicts:
-```python
-# When label_field is a string (e.g., "predictions"):
-key_fn = lambda k: "predictions_" + k
-# {"detections": ..., "raw": ...} → sample.predictions_detections, sample.predictions_raw
-
-# When label_field is a dict:
-key_fn = lambda k: label_field.get(k, k)
-# label_field={"detections": "preds"} → sample.preds
-
-# When label_field is None:
-key_fn = lambda k: k
-# {"detections": ...} → sample.detections
-```
+| Return | Stored as |
+|--------|-----------|
+| `Label` instance | Single field at `label_field` |
+| Dict, all integer keys | Frame-level, merged into `sample.frames` |
+| Dict, mixed int + string keys | String → sample fields, int → frame fields |
+| Dict, all string keys | Each key → `label_field + "_" + key` (the silent-split failure above) |
 
 ## Coordinate Normalization
 
@@ -118,31 +81,19 @@ FiftyOne uses `[0, 1]` normalized coordinates for all spatial labels:
 - **Keypoints**: `[[x, y], ...]`
 - **Polylines**: `[[[x, y], ...], ...]`
 
-If a model outputs coordinates in pixel space or 0-1000 scale, normalize before creating labels:
+If a model outputs pixel space or 0-1000 scale, normalize before creating labels:
 ```python
-# From 0-1000 scale (common in VLMs like Gemma4, Qwen3.5)
-x1, y1, x2, y2 = raw_bbox
-fo.Detection(
-    label=label,
-    bounding_box=[x1/1000, y1/1000, (x2-x1)/1000, (y2-y1)/1000],
-)
-
 # From pixel coordinates
-fo.Detection(
-    label=label,
-    bounding_box=[x/img_w, y/img_h, w/img_w, h/img_h],
-)
+fo.Detection(label=label, bounding_box=[x/img_w, y/img_h, w/img_w, h/img_h])
 ```
+
+For VLM-specific quirks (PaLI `[y, x, h, w]` order, 0–1000 scales), see `VLM-PATTERNS.md`.
 
 ## Quick Checklist
 
-When implementing `predict()` / `predict_all()` for a FiftyOne zoo model:
-
-- [ ] Image operations return a single `fo.Label` subclass, not a dict
-- [ ] Text outputs (VQA, caption, OCR) wrapped in `fo.Classification(label=text)`
-- [ ] Detection boxes are `[x, y, w, h]` in `[0, 1]` range
-- [ ] Keypoints are `[[x, y], ...]` in `[0, 1]` range
-- [ ] Extra metadata stored as dynamic attributes on the Label, not in wrapper dicts
-- [ ] Video frame-level results use integer keys in the return dict
-- [ ] `collate_fn` inherited from `TorchModelMixin` (not overridden) — see `/fiftyone-zoo-remote-model` skill for details
-- [ ] `build_get_item` returns `ImageGetItem(raw_inputs=True)` — no custom `GetItem` subclass in zoo module
+- [ ] Image ops return a single `fo.Label` subclass, not a dict
+- [ ] Text outputs wrapped in `fo.Classification(label=text)`
+- [ ] Detection boxes `[x, y, w, h]` in `[0, 1]`; keypoints `[[x, y], ...]` in `[0, 1]`
+- [ ] Extra metadata as dynamic attributes on the Label, not wrapper dicts
+- [ ] Video frame-level results use integer keys
+- [ ] `collate_fn` inherited from `TorchModelMixin`; `build_get_item` returns `ImageGetItem(raw_inputs=True)`

--- a/skills/fiftyone-zoo-remote-model/references/MANIFEST.md
+++ b/skills/fiftyone-zoo-remote-model/references/MANIFEST.md
@@ -1,0 +1,47 @@
+# Manifest & Entry Point
+
+## manifest.json
+
+**Must have a top-level `name` field.** FiftyOne skips manifests without it. The `name` determines the subdirectory under `model_zoo_dir` and the Python module name.
+
+```json
+{
+    "name": "my-org/my-model",
+    "url": "https://github.com/my-org/my-model",
+    "models": [
+        {
+            "base_name": "org/model-variant",
+            "base_filename": "model-variant",
+            "author": "Author Name",
+            "description": "Brief model description.",
+            "requirements": {
+                "packages": ["torch", "transformers>=4.50"],
+                "cpu": {"support": true},
+                "gpu": {"support": true}
+            },
+            "tags": ["detection", "classification", "torch", "VLM"]
+        }
+    ]
+}
+```
+
+## __init__.py
+
+Exports functions called by FiftyOne's zoo machinery. Uses relative imports for `zoo.py`.
+
+```python
+from .zoo import MyImageModel, MyImageModelConfig, MyVideoModel, MyVideoModelConfig
+
+def download_model(model_name: str, model_path: str) -> None:
+    """Download model weights to model_path."""
+    ...
+
+def load_model(model_name: str | None = None, model_path: str | None = None, **kwargs) -> MyImageModel | MyVideoModel:
+    """Load and return a fom.Model instance. kwargs passed from load_zoo_model."""
+    config = MyImageModelConfig({**kwargs})
+    return MyImageModel(config)
+
+def resolve_input(model_name: str, ctx) -> types.Property | None:
+    """Define operator UI inputs for FiftyOne App (optional)."""
+    ...
+```

--- a/skills/fiftyone-zoo-remote-model/references/MANIFEST.md
+++ b/skills/fiftyone-zoo-remote-model/references/MANIFEST.md
@@ -4,6 +4,8 @@
 
 **Must have a top-level `name` field.** FiftyOne skips manifests without it. The `name` determines the subdirectory under `model_zoo_dir` and the Python module name.
 
+> **First check on silent failure.** If `register_zoo_model_source` "succeeds" but `load_zoo_model` cannot find the model, verify the top-level `name` is present. Missing-`name` is a silent skip — frequently replicated bug.
+
 ```json
 {
     "name": "my-org/my-model",
@@ -33,7 +35,8 @@ Exports functions called by FiftyOne's zoo machinery. Uses relative imports for 
 from .zoo import MyImageModel, MyImageModelConfig, MyVideoModel, MyVideoModelConfig
 
 def download_model(model_name: str, model_path: str) -> None:
-    """Download model weights to model_path."""
+    """Download model weights to model_path. MUST be idempotent — safe to
+    call when weights already exist at model_path (no-op or re-verify)."""
     ...
 
 def load_model(model_name: str | None = None, model_path: str | None = None, **kwargs) -> MyImageModel | MyVideoModel:

--- a/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
+++ b/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
@@ -1,0 +1,98 @@
+# zoo.py — Class Hierarchy
+
+## Config
+
+```python
+import fiftyone.utils.torch as fout
+
+class MyModelConfig(fout.TorchImageModelConfig):
+    def __init__(self, d: dict):
+        if "raw_inputs" not in d:
+            d["raw_inputs"] = True   # Feed raw images, not stacked tensors
+        super().__init__(d)
+        self.model_path = self.parse_string(d, "model_path", default="org/model")
+        # ... other config params
+```
+
+## Model
+
+```python
+import fiftyone.core.models as fom
+from fiftyone.core.models import SupportsGetItem, TorchModelMixin
+from fiftyone.utils.torch import ImageGetItem
+
+class MyBaseModel(fom.Model, fom.SamplesMixin, SupportsGetItem, TorchModelMixin):
+    def __init__(self, config):
+        fom.SamplesMixin.__init__(self)
+        SupportsGetItem.__init__(self)
+        self._preprocess = False
+        self.config = config
+        # ... model state
+
+    # -- Required properties --
+    @property
+    def transforms(self):
+        return None
+
+    @property
+    def preprocess(self) -> bool:
+        return self._preprocess
+
+    @preprocess.setter
+    def preprocess(self, value: bool):
+        self._preprocess = value
+
+    @property
+    def ragged_batches(self) -> bool:
+        return False
+
+    @property
+    def needs_fields(self) -> dict:
+        return self._fields
+
+    @needs_fields.setter
+    def needs_fields(self, fields: dict):
+        self._fields = fields
+
+    @property
+    def has_collate_fn(self) -> bool:
+        return True
+    # See DATALOADER.md for collate_fn and GetItem options (built-in vs custom)
+
+    def build_get_item(self, field_mapping=None) -> ImageGetItem:
+        return ImageGetItem(field_mapping=field_mapping, raw_inputs=True)
+```
+
+## predict / predict_all — Handle Multiple Input Types
+
+With `ImageGetItem(raw_inputs=True)`, the DataLoader delivers PIL Images. But FiftyOne's single-sample path (`_apply_image_model_single`) passes filepath strings. Direct API calls may pass dicts. Handle all three:
+
+```python
+def predict(self, arg, sample=None):
+    return self.predict_all([arg], samples=[sample] if sample else None)[0]
+
+def predict_all(self, batch, samples=None):
+    results = []
+    for i, item in enumerate(batch):
+        sample = samples[i] if samples and i < len(samples) else None
+
+        if isinstance(item, dict):
+            image = item.get("filepath", item.get("image"))
+            prompt = item.get("prompt")
+        elif isinstance(item, str):
+            image = item       # filepath from simple path
+            prompt = None
+        else:
+            image = item       # PIL Image from DataLoader
+            prompt = None
+
+        # Get prompt from sample fields if needed
+        if prompt is None and sample and "prompt_field" in self._fields:
+            fn = self._fields["prompt_field"]
+            if sample.has_field(fn):
+                prompt = sample.get_field(fn)
+
+        prompt = prompt or self.config.prompt
+        results.append(self._run_inference(image, prompt))
+    return results
+```

--- a/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
+++ b/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
@@ -1,5 +1,15 @@
 # zoo.py — Class Hierarchy
 
+## Use these, don't replace these
+
+**Framework-first**: FiftyOne already provides the pickle-safe primitives. Subclassing or overriding these re-introduces the **Worker-pickle constraint** failures (see DATALOADER.md).
+
+| Concern | Use this | Do NOT |
+|---------|----------|--------|
+| Batch collation | `TorchModelMixin.collate_fn` (inherited) | Override `collate_fn` |
+| Dataset item loading | `fiftyone.utils.torch.ImageGetItem(raw_inputs=True)` | Subclass `GetItem` |
+| `transforms` / `preprocess` / `ragged_batches` / `needs_fields` / `has_collate_fn` | Implement on your model class | These are the seams — implement, don't avoid |
+
 ## Config
 
 ```python
@@ -8,13 +18,12 @@ import fiftyone.utils.torch as fout
 class MyModelConfig(fout.TorchImageModelConfig):
     def __init__(self, d: dict):
         if "raw_inputs" not in d:
-            d["raw_inputs"] = True   # Feed raw images, not stacked tensors
+            d["raw_inputs"] = True
         super().__init__(d)
         self.model_path = self.parse_string(d, "model_path", default="org/model")
-        # ... other config params
 ```
 
-## Model
+## Model — multi-inheritance order matters
 
 ```python
 import fiftyone.core.models as fom
@@ -27,45 +36,41 @@ class MyBaseModel(fom.Model, fom.SamplesMixin, SupportsGetItem, TorchModelMixin)
         SupportsGetItem.__init__(self)
         self._preprocess = False
         self.config = config
-        # ... model state
-
-    # -- Required properties --
-    @property
-    def transforms(self):
-        return None
 
     @property
-    def preprocess(self) -> bool:
-        return self._preprocess
+    def transforms(self): return None
 
+    @property
+    def preprocess(self) -> bool: return self._preprocess
     @preprocess.setter
-    def preprocess(self, value: bool):
-        self._preprocess = value
+    def preprocess(self, value: bool): self._preprocess = value
 
     @property
-    def ragged_batches(self) -> bool:
-        return False
+    def ragged_batches(self) -> bool: return False
 
     @property
-    def needs_fields(self) -> dict:
-        return self._fields
-
+    def needs_fields(self) -> dict: return self._fields
     @needs_fields.setter
-    def needs_fields(self, fields: dict):
-        self._fields = fields
+    def needs_fields(self, fields: dict): self._fields = fields
 
     @property
-    def has_collate_fn(self) -> bool:
-        return True
-    # See DATALOADER.md for collate_fn and GetItem options (built-in vs custom)
+    def has_collate_fn(self) -> bool: return True
 
     def build_get_item(self, field_mapping=None) -> ImageGetItem:
         return ImageGetItem(field_mapping=field_mapping, raw_inputs=True)
 ```
 
-## predict / predict_all — Handle Multiple Input Types
+## predict / predict_all — three input types
 
-With `ImageGetItem(raw_inputs=True)`, the DataLoader delivers PIL Images. But FiftyOne's single-sample path (`_apply_image_model_single`) passes filepath strings. Direct API calls may pass dicts. Handle all three:
+FiftyOne calls `predict` from three different code paths. **All three must be handled** or the model breaks on one invocation shape:
+
+| Source | Type | Where from |
+|--------|------|-----------|
+| DataLoader (multi-worker) | `PIL.Image` | `ImageGetItem(raw_inputs=True)` |
+| Single-sample path | `str` (filepath) | `_apply_image_model_single` |
+| Direct API | `dict` | User code calling `model.predict({...})` |
+
+Dispatch on `isinstance`:
 
 ```python
 def predict(self, arg, sample=None):
@@ -75,23 +80,18 @@ def predict_all(self, batch, samples=None):
     results = []
     for i, item in enumerate(batch):
         sample = samples[i] if samples and i < len(samples) else None
-
         if isinstance(item, dict):
             image = item.get("filepath", item.get("image"))
             prompt = item.get("prompt")
         elif isinstance(item, str):
-            image = item       # filepath from simple path
-            prompt = None
+            image, prompt = item, None     # filepath
         else:
-            image = item       # PIL Image from DataLoader
-            prompt = None
+            image, prompt = item, None     # PIL Image
 
-        # Get prompt from sample fields if needed
         if prompt is None and sample and "prompt_field" in self._fields:
             fn = self._fields["prompt_field"]
             if sample.has_field(fn):
                 prompt = sample.get_field(fn)
-
         prompt = prompt or self.config.prompt
         results.append(self._run_inference(image, prompt))
     return results

--- a/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
+++ b/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
@@ -60,33 +60,43 @@ class MyBaseModel(fom.Model, fom.SamplesMixin, SupportsGetItem, TorchModelMixin)
         return ImageGetItem(field_mapping=field_mapping, raw_inputs=True)
 ```
 
-## predict / predict_all — three input types
+## predict / predict_all — input dispatch
 
-FiftyOne calls `predict` from three different code paths. **All three must be handled** or the model breaks on one invocation shape:
+**FiftyOne always passes `PIL.Image` to `predict_all`** when the model inherits `SupportsGetItem` and/or `TorchModelMixin`. Every framework call site loads the image before calling the model:
 
-| Source | Type | Where from |
-|--------|------|-----------|
-| DataLoader (multi-worker) | `PIL.Image` | `ImageGetItem(raw_inputs=True)` |
-| Single-sample path | `str` (filepath) | `_apply_image_model_single` |
-| Direct API | `dict` | User code calling `model.predict({...})` |
+| Framework path | Source of input | Where (`fiftyone/core/models.py`) |
+|---|---|---|
+| `_apply_image_model_data_loader` (DataLoader) | `ImageGetItem(raw_inputs=True)` → `PIL.Image` | dispatch lines 184–191; call lines 498–502 |
+| `_apply_image_model_single` (fallback) | `foui.read(sample.filepath)` → `PIL.Image` | line 372, then `model.predict(img)` line 375 |
+| `_apply_image_model_batch` (fallback batch) | `foui.read(...)` → list of `PIL.Image` | line 417, then `model.predict_all(imgs)` line 420 |
+| `_apply_image_model_to_frames_*` (video frames) | numpy frame array from `FFmpegVideoReader` | line 566, line 672 |
 
-Dispatch on `isinstance`:
+The `Model.predict_all` contract (`fiftyone/core/models.py:2365`) lists "uint8 numpy arrays (HWC) or numpy array tensors (NHWC)". `TorchImageModel.predict_all` (`fiftyone/utils/torch.py:873`) lists "PIL images, uint8 numpy arrays, Torch tensors". Neither mentions `str`. A structural search across `fiftyone/utils/*.py` finds **zero** `isinstance(_, str)` dispatch inside any `predict` / `predict_all` — no first-party model accepts a filepath string.
+
+**Implication:** the template only needs the `PIL.Image` branch. A `str` (filepath) branch is dead code — `dataset.apply_model` never produces it and no first-party model contract supports it.
+
+For non-VLM models the body is trivial — accept the image directly:
 
 ```python
 def predict(self, arg, sample=None):
     return self.predict_all([arg], samples=[sample] if sample else None)[0]
 
 def predict_all(self, batch, samples=None):
+    return [self._run_inference(image) for image in batch]
+```
+
+**VLM exception — optional `dict` input.** For VLMs you often want per-item prompts. `apply_model` does not produce dicts either (the DataLoader still yields `PIL.Image`), so a dict shape is purely a *direct-invocation convenience* for users calling `model.predict({"image": img, "prompt": "..."})` outside the framework. If you want to expose that, branch on `isinstance(item, dict)` and fall through otherwise:
+
+```python
+def predict_all(self, batch, samples=None):
     results = []
     for i, item in enumerate(batch):
         sample = samples[i] if samples and i < len(samples) else None
         if isinstance(item, dict):
-            image = item.get("filepath", item.get("image"))
+            image = item.get("image") or item.get("filepath")
             prompt = item.get("prompt")
-        elif isinstance(item, str):
-            image, prompt = item, None     # filepath
         else:
-            image, prompt = item, None     # PIL Image
+            image, prompt = item, None     # PIL.Image (DataLoader path)
 
         if prompt is None and sample and "prompt_field" in self._fields:
             fn = self._fields["prompt_field"]
@@ -96,3 +106,5 @@ def predict_all(self, batch, samples=None):
         results.append(self._run_inference(image, prompt))
     return results
 ```
+
+If you don't want the dict convenience, drop the `isinstance` check entirely and assume `PIL.Image`.

--- a/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
+++ b/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
@@ -62,20 +62,9 @@ class MyBaseModel(fom.Model, fom.SamplesMixin, SupportsGetItem, TorchModelMixin)
 
 ## predict / predict_all — input dispatch
 
-**FiftyOne always passes `PIL.Image` to `predict_all`** when the model inherits `SupportsGetItem` and/or `TorchModelMixin`. Every framework call site loads the image before calling the model:
+`dataset.apply_model` always passes `PIL.Image` to `predict_all`. The framework loads the image from `sample.filepath` before calling the model, so do **not** add an `isinstance(_, str)` branch — it is dead code. The accepted input types are documented on the public contracts `fiftyone.core.models.Model.predict_all` (numpy HWC / NHWC) and `fiftyone.utils.torch.TorchImageModel.predict_all` (PIL / numpy / Torch tensor); neither lists `str`.
 
-| Framework path | Source of input | Where (`fiftyone/core/models.py`) |
-|---|---|---|
-| `_apply_image_model_data_loader` (DataLoader) | `ImageGetItem(raw_inputs=True)` → `PIL.Image` | dispatch lines 184–191; call lines 498–502 |
-| `_apply_image_model_single` (fallback) | `foui.read(sample.filepath)` → `PIL.Image` | line 372, then `model.predict(img)` line 375 |
-| `_apply_image_model_batch` (fallback batch) | `foui.read(...)` → list of `PIL.Image` | line 417, then `model.predict_all(imgs)` line 420 |
-| `_apply_image_model_to_frames_*` (video frames) | numpy frame array from `FFmpegVideoReader` | line 566, line 672 |
-
-The `Model.predict_all` contract (`fiftyone/core/models.py:2365`) lists "uint8 numpy arrays (HWC) or numpy array tensors (NHWC)". `TorchImageModel.predict_all` (`fiftyone/utils/torch.py:873`) lists "PIL images, uint8 numpy arrays, Torch tensors". Neither mentions `str`. A structural search across `fiftyone/utils/*.py` finds **zero** `isinstance(_, str)` dispatch inside any `predict` / `predict_all` — no first-party model accepts a filepath string.
-
-**Implication:** the template only needs the `PIL.Image` branch. A `str` (filepath) branch is dead code — `dataset.apply_model` never produces it and no first-party model contract supports it.
-
-For non-VLM models the body is trivial — accept the image directly:
+For non-VLM models, accept the image directly:
 
 ```python
 def predict(self, arg, sample=None):

--- a/skills/fiftyone-zoo-remote-model/references/VLM-PATTERNS.md
+++ b/skills/fiftyone-zoo-remote-model/references/VLM-PATTERNS.md
@@ -1,0 +1,99 @@
+# VLM Patterns
+
+Patterns for vision-language and other generative-structured-output models in
+FiftyOne remote zoo integrations. Load this when Phase 2 identifies the model
+as generative.
+
+## 1. When this reference applies
+
+Use this reference when any of the following hold:
+
+- The model produces structured output via a `generate()` (or equivalent) call
+  rather than a fixed classification/detection head.
+- Model docs mention "tool calls", "function calling", or "JSON mode".
+- The model has a vision encoder with a configurable per-image token budget.
+
+If none apply, skip this file — the patterns below add overhead that is wasted
+on a fixed-head model.
+
+## 2. Tool calling > free-form JSON for structured output
+
+Free-form JSON from VLMs is unreliable in practice: wrong keys, unquoted
+string values, broken brackets, trailing prose. Tool/function calling is the
+more reliable mechanism on any VLM that supports it.
+
+- Pass the schema (field names, types, required keys) as a tool definition.
+- Parse the tool-call payload, not free text.
+- Treat free-form JSON as a fallback only when tool calling is unavailable.
+
+## 3. Generation budget is shared with prompt length
+
+Total context = system prompt + user prompt + image tokens + output tokens.
+A long system prompt eats the budget that should produce the answer, causing
+structured output to truncate mid-object.
+
+- Keep system prompts focused on output **format**, not verbose instructions.
+- Move per-task guidance into the user prompt or schema field descriptions.
+- When output is truncating, shorten the prompt before raising `max_new_tokens`.
+
+## 4. Thinking modes interfere with tool calls
+
+Many VLMs ship a "thinking" / reasoning mode that consumes generation budget
+before producing the answer. With tool calling, the tool-call tokens can leak
+into the thinking stream as plain text and never reach the parser.
+
+- Default thinking **off** for structured operations (detection, classification,
+  segmentation, keypoints).
+- Consider enabling thinking only for free-form generation (captioning, VQA).
+- Surface a `thinking` flag on the model config so callers can override.
+
+## 5. Vision token budget tuning
+
+Many VLMs accept a per-image token budget (sometimes called soft tokens, image
+tokens, or visual tokens). Lower budgets are faster but lose detail (small
+objects, fine text); higher budgets are slower with diminishing returns past
+a model-specific knee.
+
+- Surface the budget as a config parameter on the model class.
+- Choose per-operation defaults: lower for classification/captioning, higher
+  for dense detection / OCR.
+- Document the tested range in the manifest.
+
+## 6. `skip_special_tokens=False` when output uses custom delimiters
+
+Some VLMs emit custom tokens that mark structure (tool-call start/end,
+string delimiters, coordinate markers). Decoding with
+`skip_special_tokens=True` strips them and silently breaks downstream parsing
+— the parser sees a flattened string with no structure.
+
+- Decode with `skip_special_tokens=False`.
+- Rely on the processor's `parse_response` (or equivalent helper) to interpret
+  the special tokens, rather than rolling your own splitter.
+
+## 7. Multi-tier parser fallback pattern
+
+VLMs sometimes emit slightly malformed structured output. A robust pattern:
+
+| Tier | Parser | Role |
+|------|--------|------|
+| 1 | `processor.parse_response` (or equivalent) | Official path; trust first. |
+| 2 | Custom parser | Handles the few common malformations only. |
+| 3 | Plain decode | Return empty / raw text; do not invent structure. |
+
+Bound tier 2 by the **Bounded repair scope** principle (see
+`DEBUGGING-PRINCIPLES.md`): repair the few most common malformations and stop.
+Unbounded repair masks model-quality regressions.
+
+## 8. Coordinate-convention quirks
+
+Many VLMs do **not** use FiftyOne's `[x, y, w, h]` in `[0, 1]`. Common
+alternatives:
+
+- `[y1, x1, y2, x2]` (PaLI convention) — y before x, corners not size.
+- `0–1000` integer normalized scale rather than `0.0–1.0` floats.
+- Pixel coordinates against the resized model input, not the original image.
+
+Verify the convention against a **known-position spatial example** (an object
+whose bbox you can eyeball) before trusting any output. Centralize the
+conversion in a single helper method on the model class. Do not bake the
+conversion into prompt strings; do not scatter it across call sites.

--- a/skills/fiftyone-zoo-remote-model/references/VLM-PATTERNS.md
+++ b/skills/fiftyone-zoo-remote-model/references/VLM-PATTERNS.md
@@ -63,12 +63,16 @@ a model-specific knee.
 
 Some VLMs emit custom tokens that mark structure (tool-call start/end,
 string delimiters, coordinate markers). Decoding with
-`skip_special_tokens=True` strips them and silently breaks downstream parsing
-— the parser sees a flattened string with no structure.
+`skip_special_tokens=True` strips them and silently breaks downstream parsing.
 
-- Decode with `skip_special_tokens=False`.
-- Rely on the processor's `parse_response` (or equivalent helper) to interpret
-  the special tokens, rather than rolling your own splitter.
+- Decode with `skip_special_tokens=False` to preserve markers.
+- A few model families ship a typed structured-output decoder (e.g., Gemma's
+  `processor.parse_response`, Florence-2's `processor.post_process_generation`).
+  Use it when present.
+- Most VLMs (Qwen-VL, LLaVA, Idefics, Molmo, etc.) ship only
+  `processor.batch_decode()` and require model-specific parsing of the decoded
+  text — `json.loads`, regex, or XML extraction against the model's documented
+  output spec. Do not assume a helper exists.
 
 ## 7. Multi-tier parser fallback pattern
 
@@ -76,9 +80,12 @@ VLMs sometimes emit slightly malformed structured output. A robust pattern:
 
 | Tier | Parser | Role |
 |------|--------|------|
-| 1 | `processor.parse_response` (or equivalent) | Official path; trust first. |
-| 2 | Custom parser | Handles the few common malformations only. |
+| 1 | Model-specific processor helper, if shipped (e.g., Gemma's `parse_response`) | Trust the typed output. |
+| 2 | Custom parser over `batch_decode` text | Handles the few common malformations only. |
 | 3 | Plain decode | Return empty / raw text; do not invent structure. |
+
+If your model has no tier-1 helper, tier 2 *is* your primary path — write it
+against the model's documented output format, not from observed samples.
 
 Bound tier 2 by the **Bounded repair scope** principle (see
 `DEBUGGING-PRINCIPLES.md`): repair the few most common malformations and stop.

--- a/skills/fiftyone-zoo-remote-model/template/__init__.py
+++ b/skills/fiftyone-zoo-remote-model/template/__init__.py
@@ -1,23 +1,27 @@
 """Entry points for the remote zoo source. Manifest top-level `name` is required."""
 
+from typing import Any
+
 # framework-first: relative import keeps the worker-pickle path resolvable
-from .zoo import YourModel
+from .zoo import YourModel, YourModelConfig
 
 
 def download_model(model_name: str, model_path: str) -> None:
-    """Download weights to model_path. Must be idempotent."""
+    """Download weights to model_path. FiftyOne guards re-calls; not always invoked."""
     raise NotImplementedError
 
 
 def load_model(
     model_name: str | None = None,
     model_path: str | None = None,
-    **kwargs,
-) -> "fiftyone.core.models.Model":
-    """Return a model instance, not a config."""
-    return YourModel(model_name=model_name, model_path=model_path, **kwargs)
+    **kwargs: Any,
+) -> YourModel:
+    """FiftyOne calls with positional model_name, model_path, and forwarded kwargs."""
+    config_dict: dict[str, Any] = {"model_path": model_path, "model_name": model_name}
+    config_dict.update(kwargs)
+    return YourModel(YourModelConfig(config_dict))
 
 
-# Optional: implement only if the model is invoked from an operator UI.
+# Optional: implement only if invoked from an operator UI.
 # def resolve_input(model_name: str, ctx) -> "fiftyone.operators.types.Property | None":
 #     return None

--- a/skills/fiftyone-zoo-remote-model/template/__init__.py
+++ b/skills/fiftyone-zoo-remote-model/template/__init__.py
@@ -1,0 +1,23 @@
+"""Entry points for the remote zoo source. Manifest top-level `name` is required."""
+
+# framework-first: relative import keeps the worker-pickle path resolvable
+from .zoo import YourModel
+
+
+def download_model(model_name: str, model_path: str) -> None:
+    """Download weights to model_path. Must be idempotent."""
+    raise NotImplementedError
+
+
+def load_model(
+    model_name: str | None = None,
+    model_path: str | None = None,
+    **kwargs,
+) -> "fiftyone.core.models.Model":
+    """Return a model instance, not a config."""
+    return YourModel(model_name=model_name, model_path=model_path, **kwargs)
+
+
+# Optional: implement only if the model is invoked from an operator UI.
+# def resolve_input(model_name: str, ctx) -> "fiftyone.operators.types.Property | None":
+#     return None

--- a/skills/fiftyone-zoo-remote-model/template/manifest.json
+++ b/skills/fiftyone-zoo-remote-model/template/manifest.json
@@ -1,0 +1,18 @@
+{
+    "name": "your-org/your-model",
+    "url": "https://github.com/your-org/your-model",
+    "models": [
+        {
+            "base_name": "your-org/your-model-variant",
+            "base_filename": "your-model-variant",
+            "author": "Your Name",
+            "description": "Brief description.",
+            "requirements": {
+                "packages": ["torch"],
+                "cpu": {"support": true},
+                "gpu": {"support": true}
+            },
+            "tags": ["torch"]
+        }
+    ]
+}

--- a/skills/fiftyone-zoo-remote-model/template/zoo.py
+++ b/skills/fiftyone-zoo-remote-model/template/zoo.py
@@ -1,0 +1,77 @@
+# worker-pickle constraint: no pickle-bound objects defined in this module
+from __future__ import annotations
+
+from typing import Any
+
+import fiftyone.core.models as fom
+import fiftyone.utils.torch as fout
+from fiftyone.core.models import SupportsGetItem, TorchModelMixin
+from fiftyone.utils.torch import ImageGetItem
+
+
+class YourModelConfig(fout.TorchImageModelConfig):
+    def __init__(self, d: dict):
+        if "raw_inputs" not in d:
+            d["raw_inputs"] = True
+        super().__init__(d)
+        self.model_path = self.parse_string(d, "model_path", default="org/your-model")
+
+
+# framework-first: do not subclass GetItem (use ImageGetItem)
+# framework-first: do not override collate_fn (inherited from TorchModelMixin)
+class YourModel(fom.Model, fom.SamplesMixin, SupportsGetItem, TorchModelMixin):
+    def __init__(self, config: YourModelConfig):
+        fom.SamplesMixin.__init__(self)
+        SupportsGetItem.__init__(self)
+        self.config = config
+        self._preprocess = False
+        self._fields: dict = {}
+        self._model = self._load_model(config)
+
+    def _load_model(self, config: YourModelConfig) -> Any:
+        raise NotImplementedError("Load and return the underlying model here.")
+
+    @property
+    def transforms(self) -> Any | None:
+        return None
+
+    @property
+    def preprocess(self) -> bool:
+        return self._preprocess
+
+    @preprocess.setter
+    def preprocess(self, value: bool) -> None:
+        self._preprocess = value
+
+    @property
+    def ragged_batches(self) -> bool:
+        return False
+
+    @property
+    def needs_fields(self) -> dict:
+        return self._fields
+
+    @needs_fields.setter
+    def needs_fields(self, fields: dict) -> None:
+        self._fields = fields
+
+    @property
+    def has_collate_fn(self) -> bool:
+        return True
+
+    def build_get_item(self, field_mapping: dict | None = None) -> ImageGetItem:
+        return ImageGetItem(field_mapping=field_mapping, raw_inputs=True)
+
+    def predict(self, arg: Any, sample: Any | None = None) -> Any:
+        return self.predict_all([arg], samples=[sample] if sample else None)[0]
+
+    def predict_all(self, args: list, samples: list | None = None) -> list:
+        # schema compliance ≠ correctness: verify outputs against ground-truth examples
+        for item in args:
+            if isinstance(item, dict):
+                pass  # {"filepath"|"image": ..., "prompt": ...}
+            elif isinstance(item, str):
+                pass  # filepath
+            else:
+                pass  # PIL.Image
+        raise NotImplementedError("Run inference and return list[fo.Label].")

--- a/skills/fiftyone-zoo-remote-model/template/zoo.py
+++ b/skills/fiftyone-zoo-remote-model/template/zoo.py
@@ -15,6 +15,7 @@ class YourModelConfig(fout.TorchImageModelConfig):
             d["raw_inputs"] = True
         super().__init__(d)
         self.model_path = self.parse_string(d, "model_path", default="org/your-model")
+        self.model_name = d.get("model_name")
 
 
 # framework-first: do not subclass GetItem (use ImageGetItem)

--- a/skills/fiftyone-zoo-remote-model/template/zoo.py
+++ b/skills/fiftyone-zoo-remote-model/template/zoo.py
@@ -68,11 +68,12 @@ class YourModel(fom.Model, fom.SamplesMixin, SupportsGetItem, TorchModelMixin):
 
     def predict_all(self, args: list, samples: list | None = None) -> list:
         # schema compliance ≠ correctness: verify outputs against ground-truth examples
+        # dataset.apply_model always yields PIL.Image (DataLoader path); the dict
+        # branch is an optional VLM convenience for direct model.predict({...}) —
+        # drop it if you don't expose that user-facing API.
         for item in args:
             if isinstance(item, dict):
-                pass  # {"filepath"|"image": ..., "prompt": ...}
-            elif isinstance(item, str):
-                pass  # filepath
+                pass  # VLM direct invocation: {"image": PIL.Image, "prompt": str}
             else:
-                pass  # PIL.Image
+                pass  # PIL.Image — normal dataset.apply_model path
         raise NotImplementedError("Run inference and return list[fo.Label].")


### PR DESCRIPTION
## Related Issues

N/A

## What does this PR do?

Adds a new skill for remote Model Zoo integration in FiftyOne. Uses lessons learned from the [Gemma4 model integration](https://github.com/Burhan-Q/gemma4)

## Type of Change

- [x] New skill
- [ ] Skill improvement (bug fix, better instructions, edge cases)
- [ ] New agent integration
- [ ] Documentation / repo infrastructure
- [ ] Other

## Skill Checklist

<!-- Complete this section if you're adding or modifying a skill -->

- [x] `SKILL.md` has YAML frontmatter with, `name` and `description` at least and all keys are universally valid
- [x] Key Directives section is present (ALWAYS/NEVER rules)
- [x] Complete Workflow section with code examples at each step
- [x] Troubleshooting section covers common failure modes
- [x] `AGENTS.md` updated with the skill entry
- [x] Tested end-to-end with at least one AI assistant
- [x] `node scripts/validate-template.mjs` passes (also checked with `skills-ref validate`

## Testing

Validated via two end-to-end cold-agent runs in Claude Code. Skill derived from work on [Gemma4 integration](https://github.com/Burhan-Q/gemma4)