### PR TITLE
Add README files for each individual skill

### DIFF
--- a/skills/fiftyone-code-style/README.md
+++ b/skills/fiftyone-code-style/README.md
@@ -1,0 +1,40 @@
+# Code Style
+
+Write Python code that follows FiftyOne's official conventions: module structure, imports, logging, and API patterns.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-code-style** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"Write a FiftyOne utility module that computes label statistics"
+"Refactor this code to follow FiftyOne conventions"
+"Help me write a custom dataset importer following FiftyOne patterns"
+```
+
+The skill applies FiftyOne's standard module structure, import ordering, logging setup, type hints, and docstring style.
+
+## When to use
+
+Use this skill when:
+- Contributing code to the FiftyOne core repo
+- Writing plugins that will be shared publicly
+- Authoring code that integrates with FiftyOne's internal APIs
+- Reviewing or refactoring existing FiftyOne-adjacent code
+
+## See also
+
+- [FiftyOne contributing guide](https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md)
+- [Plugin development docs](https://docs.voxel51.com/plugins/developing_plugins.html)

--- a/skills/fiftyone-create-notebook/README.md
+++ b/skills/fiftyone-create-notebook/README.md
@@ -1,0 +1,46 @@
+# Create Notebook
+
+Generate Jupyter notebooks for FiftyOne workflows: getting-started guides, tutorials, recipes, and full ML pipelines.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-create-notebook** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- Jupyter (`pip install jupyter`)
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"Create a getting-started notebook for FiftyOne"
+"Write a tutorial notebook on how to evaluate object detection models"
+"Generate a quick recipe for loading a COCO dataset and filtering by label"
+"Build an end-to-end ML pipeline notebook from data import to evaluation"
+```
+
+The skill classifies your request (getting-started, tutorial, recipe, or full pipeline) and generates a structured, runnable notebook.
+
+## Example
+
+```
+"Create a tutorial notebook that shows how to find duplicates using FiftyOne Brain"
+```
+
+The notebook will include:
+- Setup and installation cells
+- Dataset loading with the FiftyOne Zoo
+- Step-by-step workflow with explanations
+- Visualization in the FiftyOne App
+
+## See also
+
+- [FiftyOne tutorials](https://docs.voxel51.com/tutorials/index.html)
+- [FiftyOne recipes](https://docs.voxel51.com/recipes/index.html)

--- a/skills/fiftyone-dataset-curation/README.md
+++ b/skills/fiftyone-dataset-curation/README.md
@@ -1,0 +1,50 @@
+# Dataset Curation
+
+End-to-end curation pipeline: inspect quality, audit annotations, find duplicates, explore embeddings, and build curated splits.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-dataset-curation** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server)
+- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain)
+
+## Usage
+
+Load a dataset in FiftyOne, then ask your AI assistant:
+
+```
+"Curate my dataset: check quality, find duplicates, and build a clean training split"
+"Audit the annotations in my detection dataset"
+"Analyze class distribution and flag imbalanced classes"
+"Create a stratified train/val/test split"
+```
+
+The skill runs each phase sequentially and presents findings before making any changes.
+
+## Example
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+dataset = foz.load_zoo_dataset("quickstart")
+```
+
+Then ask your assistant:
+
+```
+"Curate the quickstart dataset: check for quality issues and near-duplicates"
+```
+
+## See also
+
+- [Dataset curation docs](https://docs.voxel51.com/user_guide/brain.html)
+- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain)

--- a/skills/fiftyone-dataset-export/README.md
+++ b/skills/fiftyone-dataset-export/README.md
@@ -1,0 +1,53 @@
+# Dataset Export
+
+Export FiftyOne datasets to standard formats for training, sharing, or publishing.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-dataset-export** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server) (optional, recommended for App control)
+
+## Usage
+
+Load a dataset in FiftyOne, then ask your AI assistant:
+
+```
+"Export my dataset to COCO format at /tmp/export"
+"Save this dataset to Hugging Face Hub as my-org/my-dataset"
+"Export the current view as a YOLO dataset"
+```
+
+The skill confirms the dataset, label fields, and export path with you before writing anything.
+
+## Example
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+# Load a dataset to export
+dataset = foz.load_zoo_dataset("quickstart")
+```
+
+Then ask your assistant:
+
+```
+"Export quickstart to COCO detection format at /tmp/quickstart-coco"
+```
+
+## Supported formats
+
+COCO, YOLO, VOC, CVAT, Open Images, CSV, TFRecords, and Hugging Face Hub.
+
+## See also
+
+- [Dataset Export docs](https://docs.voxel51.com/user_guide/export_datasets.html)
+- [Hugging Face Hub export](https://docs.voxel51.com/integrations/huggingface.html)

--- a/skills/fiftyone-dataset-import/README.md
+++ b/skills/fiftyone-dataset-import/README.md
@@ -1,0 +1,43 @@
+# Dataset Import
+
+Import any dataset into FiftyOne with automatic format detection. Supports local files, Hugging Face Hub, cloud storage, and multimodal grouped data.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-dataset-import** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server) (optional, recommended for App control)
+
+## Usage
+
+Start the MCP server and ask your AI assistant:
+
+```
+"Import the COCO dataset from /path/to/data"
+"Load the keremberke/license-plate-object-detection dataset from Hugging Face"
+"Import this folder of images, there are cameras and LiDAR files grouped by scene"
+```
+
+The skill scans your data, auto-detects the format and media types, and loads the dataset into FiftyOne. It handles images, videos, point clouds, COCO, YOLO, VOC, KITTI, and more without you specifying the format.
+
+## Example
+
+```python
+import fiftyone as fo
+
+# After the skill runs, access your dataset
+dataset = fo.load_dataset("my-dataset")
+print(dataset)
+```
+
+## See also
+
+- [Dataset Import docs](https://docs.voxel51.com/user_guide/dataset_creation/index.html)
+- [Hugging Face Hub integration](https://docs.voxel51.com/integrations/huggingface.html)

--- a/skills/fiftyone-dataset-inference/README.md
+++ b/skills/fiftyone-dataset-inference/README.md
@@ -1,0 +1,48 @@
+# Dataset Inference
+
+Run ML model inference on a FiftyOne dataset using Zoo models or your own. Supports detection, classification, segmentation, and embeddings.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-dataset-inference** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server) (optional, recommended for operator-based inference)
+
+## Usage
+
+Load a dataset in FiftyOne, then ask your AI assistant:
+
+```
+"Run YOLO object detection on my dataset"
+"Compute CLIP embeddings for all images"
+"Apply a segmentation model and store results in a new field"
+```
+
+The skill discovers available models dynamically, confirms the model and output field with you, then runs inference.
+
+## Example
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+dataset = foz.load_zoo_dataset("quickstart")
+```
+
+Then ask your assistant:
+
+```
+"Run object detection on the quickstart dataset using a YOLO model"
+```
+
+## See also
+
+- [Model Zoo docs](https://docs.voxel51.com/model_zoo/index.html)
+- [Applying models docs](https://docs.voxel51.com/user_guide/model_zoo/models.html)

--- a/skills/fiftyone-develop-plugin/README.md
+++ b/skills/fiftyone-develop-plugin/README.md
@@ -1,0 +1,48 @@
+# Develop Plugin
+
+Scaffold and implement custom FiftyOne plugins: operators, panels, and JavaScript components.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-develop-plugin** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- Python 3.8+
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"Create a FiftyOne operator that filters samples by confidence score"
+"Build a panel that shows a class distribution chart"
+"Scaffold a plugin that integrates with my annotation tool"
+```
+
+The skill asks clarifying questions, presents the file structure and design for your approval, then generates the full plugin code with tests.
+
+## Example output
+
+```
+my-plugin/
+├── fiftyone.yml
+├── __init__.py        # operator/panel definitions
+└── README.md
+```
+
+Install the generated plugin:
+
+```bash
+fiftyone plugins create ./my-plugin
+```
+
+## See also
+
+- [Plugin development docs](https://docs.voxel51.com/plugins/developing_plugins.html)
+- [FiftyOne Plugins](https://github.com/voxel51/fiftyone-plugins)

--- a/skills/fiftyone-develop-plugin/README.md
+++ b/skills/fiftyone-develop-plugin/README.md
@@ -39,7 +39,7 @@ my-plugin/
 Install the generated plugin:
 
 ```bash
-fiftyone plugins create ./my-plugin
+fiftyone plugins create my-plugin
 ```
 
 ## See also

--- a/skills/fiftyone-embeddings-visualization/README.md
+++ b/skills/fiftyone-embeddings-visualization/README.md
@@ -1,0 +1,50 @@
+# Embeddings Visualization
+
+Visualize your dataset in 2D using UMAP or t-SNE to explore structure, find clusters, and identify outliers.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-embeddings-visualization** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server)
+- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain) (`pip install fiftyone-brain`)
+- `@voxel51/brain` plugin
+
+## Usage
+
+Load a dataset in FiftyOne, then ask your AI assistant:
+
+```
+"Visualize my dataset embeddings with UMAP"
+"Compute CLIP embeddings and show the 2D projection"
+"Color the embedding plot by class label and find outliers"
+```
+
+The skill computes embeddings if they don't exist, reduces them to 2D, and opens the Embeddings panel in the FiftyOne App.
+
+## Example
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+dataset = foz.load_zoo_dataset("quickstart")
+```
+
+Then ask your assistant:
+
+```
+"Compute CLIP embeddings for quickstart and show a UMAP visualization"
+```
+
+## See also
+
+- [Embeddings visualization docs](https://docs.voxel51.com/brain.html#visualizing-embeddings)
+- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain)

--- a/skills/fiftyone-eval-plugin/README.md
+++ b/skills/fiftyone-eval-plugin/README.md
@@ -1,0 +1,39 @@
+# Eval Plugin
+
+Evaluate any FiftyOne plugin for quality, security, and agent-readiness. Get a structured report with scores and actionable recommendations.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-eval-plugin** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"Evaluate the @voxel51/brain plugin"
+"Audit this plugin I just built before I share it"
+"Check this community plugin for security issues"
+"Review my plugin for agent-readiness"
+```
+
+The skill reads every source and configuration file in the plugin, checks for security patterns, code quality, and operator design, then produces a structured report with a score and specific recommendations.
+
+## What gets checked
+
+- Security: dangerous code patterns, input validation, secret handling
+- Code quality: operator structure, error handling, schema definitions
+- Agent-readiness: operator descriptions, input/output clarity, executability
+
+## See also
+
+- [Plugin development docs](https://docs.voxel51.com/plugins/developing_plugins.html)
+- [FiftyOne Plugins](https://github.com/voxel51/fiftyone-plugins)

--- a/skills/fiftyone-find-duplicates/README.md
+++ b/skills/fiftyone-find-duplicates/README.md
@@ -1,0 +1,50 @@
+# Find Duplicates
+
+Find and remove duplicate or near-duplicate images from a FiftyOne dataset using brain similarity.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-find-duplicates** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server)
+- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain) (`pip install fiftyone-brain`)
+- `@voxel51/brain` plugin
+
+## Usage
+
+Load a dataset in FiftyOne, then ask your AI assistant:
+
+```
+"Find duplicate images in my dataset"
+"Remove near-duplicates and keep only unique samples"
+"Show me which images are visually similar"
+```
+
+The skill computes similarity embeddings, identifies duplicates above a configurable threshold, and lets you review them in the App before deleting.
+
+## Example
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+dataset = foz.load_zoo_dataset("quickstart")
+```
+
+Then ask your assistant:
+
+```
+"Find near-duplicate images in the quickstart dataset"
+```
+
+## See also
+
+- [Deduplication docs](https://docs.voxel51.com/brain.html#brain-similarity)
+- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain)

--- a/skills/fiftyone-generate-data-lens-connector/README.md
+++ b/skills/fiftyone-generate-data-lens-connector/README.md
@@ -1,0 +1,45 @@
+# Generate Data Lens Connector
+
+Generate a fully functional Data Lens connector plugin from your external database schema.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-generate-data-lens-connector** from the menu.
+
+## Requirements
+
+- [FiftyOne Enterprise](https://docs.voxel51.com/enterprise/index.html) (Data Lens is an Enterprise-only feature)
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"Generate a Data Lens connector for my PostgreSQL database"
+"Create a connector that lets me browse my BigQuery image table in FiftyOne"
+"Build a Data Lens plugin from this database schema"
+```
+
+Provide your database schema (table names, column types, and which columns map to image paths or labels) and the skill generates a complete `DataLensOperator` plugin ready to install.
+
+## Example
+
+```
+"Here is my PostgreSQL schema:
+  images(id, filepath, label, confidence, created_at)
+Generate a Data Lens connector so I can browse this in FiftyOne."
+```
+
+## Note
+
+> Data Lens is a FiftyOne Enterprise feature. The generated connector requires a FiftyOne Enterprise deployment to run.
+
+## See also
+
+- [FiftyOne Enterprise docs](https://docs.voxel51.com/enterprise/index.html)
+- [Plugin development docs](https://docs.voxel51.com/plugins/developing_plugins.html)

--- a/skills/fiftyone-issue-triage/README.md
+++ b/skills/fiftyone-issue-triage/README.md
@@ -1,0 +1,43 @@
+# Issue Triage
+
+Triage FiftyOne GitHub issues: validate status, categorize, and generate responses automatically.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-issue-triage** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- [GitHub CLI](https://cli.github.com/) (`gh`) authenticated
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"Triage issue #7234 in the FiftyOne repo"
+"Check if this bug report has already been fixed"
+"Review the last 10 open issues and categorize them"
+```
+
+The skill fetches the issue, searches related commits and issues, assesses the current status, and drafts a response.
+
+## Categories
+
+| Category | Description |
+|---|---|
+| Already Fixed | Resolved in a recent commit or release |
+| Won't Fix | By design, out of scope, or external behavior |
+| Not Reproducible | Cannot reproduce with provided information |
+| No Longer Relevant | Stale, deprecated, or outdated version |
+| Still Valid | Confirmed bug or valid feature request |
+
+## See also
+
+- [FiftyOne GitHub Issues](https://github.com/voxel51/fiftyone/issues)
+- [Contributing guide](https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md)

--- a/skills/fiftyone-model-evaluation/README.md
+++ b/skills/fiftyone-model-evaluation/README.md
@@ -1,0 +1,53 @@
+# Model Evaluation
+
+Evaluate model predictions against ground truth. Compute mAP, precision, recall, confusion matrices, and analyze failure cases.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-model-evaluation** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server) (optional, recommended for operator-based evaluation)
+- `@voxel51/evaluation` plugin (optional, for operator-based evaluation)
+
+## Usage
+
+Load a dataset with both predictions and ground truth, then ask your AI assistant:
+
+```
+"Evaluate my YOLO predictions against ground truth"
+"Compute mAP for my detection model"
+"Show me the confusion matrix and top failure cases"
+```
+
+The skill checks for the required fields, runs the evaluation protocol, and opens the results in the App so you can drill into TP/FP/FN samples.
+
+## Example
+
+```python
+import fiftyone as fo
+import fiftyone.zoo as foz
+
+# Load a dataset with predictions
+dataset = foz.load_zoo_dataset("quickstart")
+
+import fiftyone.zoo as foz
+model = foz.load_zoo_model("yolov8n-coco-torch")
+dataset.apply_model(model, label_field="predictions")
+```
+
+Then ask your assistant:
+
+```
+"Evaluate the predictions field against ground_truth in the quickstart dataset"
+```
+
+## See also
+
+- [Model evaluation docs](https://docs.voxel51.com/user_guide/evaluation.html)

--- a/skills/fiftyone-model-evaluation/README.md
+++ b/skills/fiftyone-model-evaluation/README.md
@@ -30,17 +30,6 @@ The skill checks for the required fields, runs the evaluation protocol, and open
 
 ## Example
 
-```python
-import fiftyone as fo
-import fiftyone.zoo as foz
-
-# Load a dataset with predictions
-dataset = foz.load_zoo_dataset("quickstart")
-
-import fiftyone.zoo as foz
-model = foz.load_zoo_model("yolov8n-coco-torch")
-dataset.apply_model(model, label_field="predictions")
-```
 
 Then ask your assistant:
 

--- a/skills/fiftyone-troubleshoot/README.md
+++ b/skills/fiftyone-troubleshoot/README.md
@@ -1,0 +1,43 @@
+# Troubleshoot
+
+Diagnose and fix common FiftyOne issues: dataset persistence, App connectivity, MongoDB errors, video codecs, and more.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-troubleshoot** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"My dataset disappeared after restarting, how do I get it back?"
+"The FiftyOne App won't open, it just hangs"
+"I'm getting a MongoDB connection error"
+"Video samples show a codec error in the App"
+"My operator is registered but not showing up in the App"
+```
+
+The skill identifies the root cause, explains what went wrong and why, proposes a fix, and waits for your confirmation before applying anything.
+
+## Covered issues
+
+- Dataset persistence and MongoDB connectivity
+- App launch failures and port conflicts
+- Plugin and operator not appearing
+- Video codec incompatibilities
+- Notebook connectivity (`fo.launch_app` in Jupyter)
+- Performance issues with large datasets
+
+## See also
+
+- [FiftyOne FAQ](https://docs.voxel51.com/faq/index.html)
+- [Discord community](https://discord.gg/fiftyone-community)

--- a/skills/fiftyone-voodo-design/README.md
+++ b/skills/fiftyone-voodo-design/README.md
@@ -1,0 +1,42 @@
+# VOODO Design
+
+Build FiftyOne plugin UIs using VOODO (`@voxel51/voodo`), the official React component library.
+
+## Install
+
+```bash
+curl -sL skil.sh | sh -s -- voxel51/fiftyone-skills
+```
+
+When prompted, select **fiftyone-voodo-design** from the menu.
+
+## Requirements
+
+- [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
+- Node.js 18+
+- Familiarity with React and FiftyOne plugin development
+
+## Usage
+
+Ask your AI assistant:
+
+```
+"Build a panel that shows a bar chart of class distributions using VOODO"
+"Create a settings form for my plugin using VOODO components"
+"Style this plugin panel to match the FiftyOne design system"
+```
+
+The skill fetches the complete VOODO component API reference before writing any code, ensuring it uses the correct design tokens, component props, and composition patterns.
+
+## Example
+
+```
+"Create a FiftyOne panel with a search input and a scrollable list of results using VOODO"
+```
+
+The skill will generate a React component using VOODO's `Input`, `ScrollArea`, and layout components with the correct design tokens.
+
+## See also
+
+- [VOODO documentation](https://voodo.dev.fiftyone.ai)
+- [Plugin development docs](https://docs.voxel51.com/plugins/developing_plugins.html)


### PR DESCRIPTION
## Related Issues

Companion PR to voxel51/fiftyone#7509

## What does this PR do?

Adds a `README.md` for all 16 skills in this repo, including install instructions, requirements, example prompts, code snippets, and related links.

## Type of Change

* [ ] New skill
* [x] Skill improvement (bug fix, better instructions, edge cases)
* [ ] New agent integration
* [x] Documentation / repo infrastructure
* [ ] Other

## Testing

Tested the updated install flow and verified all README links and anchors render correctly.