### PR TITLE
Clean up Brain refs and README examples

### DIFF
--- a/skills/fiftyone-dataset-curation/README.md
+++ b/skills/fiftyone-dataset-curation/README.md
@@ -14,7 +14,6 @@ When prompted, select **fiftyone-dataset-curation** from the menu.
 
 - [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
 - [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server)
-- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain)
 
 ## Usage
 

--- a/skills/fiftyone-dataset-import/README.md
+++ b/skills/fiftyone-dataset-import/README.md
@@ -29,12 +29,15 @@ The skill scans your data, auto-detects the format and media types, and loads th
 
 ## Example
 
-```python
-import fiftyone as fo
+```bash
+# Download sample COCO data to ~/fiftyone/coco-2017/validation
+fiftyone zoo datasets download coco-2017 --split validation
+```
 
-# After the skill runs, access your dataset
-dataset = fo.load_dataset("my-dataset")
-print(dataset)
+Then ask your assistant:
+
+```
+"Import the COCO 2017 validation dataset from ~/fiftyone/coco-2017/validation"
 ```
 
 ## See also

--- a/skills/fiftyone-dataset-import/README.md
+++ b/skills/fiftyone-dataset-import/README.md
@@ -37,7 +37,21 @@ fiftyone zoo datasets download coco-2017 --split validation
 Then ask your assistant:
 
 ```
-"Import the COCO 2017 validation dataset from ~/fiftyone/coco-2017/validation"
+"Import the COCO 2017 validation dataset from ~/fiftyone/coco-2017/validation and name it coco-2017-validation"
+```
+
+After the skill runs, verify in Python:
+
+```python
+import fiftyone as fo
+dataset = fo.load_dataset("coco-2017-validation")
+print(dataset)
+```
+
+Or ask your assistant to open it in the App:
+
+```
+"Launch the FiftyOne App with the coco-2017-validation dataset"
 ```
 
 ## See also

--- a/skills/fiftyone-embeddings-visualization/README.md
+++ b/skills/fiftyone-embeddings-visualization/README.md
@@ -14,8 +14,7 @@ When prompted, select **fiftyone-embeddings-visualization** from the menu.
 
 - [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
 - [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server)
-- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain) (`pip install fiftyone-brain`)
-- `@voxel51/brain` plugin
+- [`@voxel51/brain`](https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/brain) plugin
 
 ## Usage
 

--- a/skills/fiftyone-find-duplicates/README.md
+++ b/skills/fiftyone-find-duplicates/README.md
@@ -14,8 +14,7 @@ When prompted, select **fiftyone-find-duplicates** from the menu.
 
 - [FiftyOne](https://docs.voxel51.com/getting_started/install.html)
 - [FiftyOne MCP Server](https://github.com/voxel51/fiftyone-mcp-server)
-- [FiftyOne Brain](https://github.com/voxel51/fiftyone-brain) (`pip install fiftyone-brain`)
-- `@voxel51/brain` plugin
+- [`@voxel51/brain`](https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/brain) plugin
 
 ## Usage
 


### PR DESCRIPTION
Addresses review feedback from @brimoor on #40:

* `fiftyone-dataset-import`: Made the Example section self-contained by adding a dataset zoo download step so users can follow the example end-to-end
* `fiftyone-dataset-curation`, `fiftyone-embeddings-visualization`, `fiftyone-find-duplicates`: Removed FiftyOne Brain from `## Requirements` since it already ships with `pip install fiftyone`
* `fiftyone-embeddings-visualization`, `fiftyone-find-duplicates`: Added a link to the `@voxel51/brain` plugin so users can easily find it and understand what it is
