### PR TITLE
Consolidate hackday feedback into fiftyone-develop-plugin skill

### DIFF
--- a/skills/fiftyone-develop-plugin/EXECUTION-STORE.md
+++ b/skills/fiftyone-develop-plugin/EXECUTION-STORE.md
@@ -39,27 +39,26 @@ def on_load(self, ctx):
 
 ## Store Key Strategy
 
-Use namespaced keys to avoid conflicts between plugins and datasets:
+Use a plugin-unique name to avoid collisions with other plugins. `ctx.store()` already scopes by `dataset_id` internally — no need to embed dataset name in the key.
 
 ```python
 class MyPanel(foo.Panel):
-    version = "v1"  # For migration support
+    version = "v1"  # Bump to invalidate cached data on schema changes
 
-    def _get_store_key(self, ctx):
-        """Generate unique store key for this panel instance."""
+    def _get_store_key(self):
+        """Plugin-unique store name. Dataset scoping is handled by ctx.store() automatically."""
         plugin_name = self.config.name.split("/")[-1]
-        dataset_id = ctx.dataset._doc.id
-        return f"{plugin_name}_store_{dataset_id}_{self.version}"
+        return f"{plugin_name}_v{self.version}"
 
     def on_load(self, ctx):
-        store = ctx.store(self._get_store_key(ctx))
+        store = ctx.store(self._get_store_key())
         # ...
 ```
 
 **Key components:**
-- **Plugin name**: Extracted from config, avoids hardcoding
-- **Dataset ID**: Prevents cross-dataset conflicts
-- **Version**: Enables migration when schema changes
+- **Plugin name**: Avoids collisions with other plugins on the same dataset
+- **Version** (optional): Invalidates cached data when schema changes
+- ~~**Dataset name**~~: Not needed — `ctx.store()` internally passes `dataset._doc.id` to the store backend
 
 ---
 
@@ -364,12 +363,12 @@ def _safe_get(self, ctx, key, default=None):
 class MyOperator(foo.Operator):
     version = "v1"
 
-    def _get_store_key(self, ctx):
+    def _get_store_key(self):
         plugin_name = self.config.name.split("/")[-1]
-        return f"{plugin_name}_{ctx.dataset._doc.id}_{self.version}"
+        return f"{plugin_name}_v{self.version}"
 
     def execute(self, ctx):
-        store = ctx.store(self._get_store_key(ctx))
+        store = ctx.store(self._get_store_key())
 
         # Check cache
         cached = store.get("result")

--- a/skills/fiftyone-develop-plugin/HYBRID-PLUGINS.md
+++ b/skills/fiftyone-develop-plugin/HYBRID-PLUGINS.md
@@ -126,7 +126,7 @@ class MyHybridPanel(Panel):
 
     def get_status(self, ctx):
         """Return current processing status"""
-        store = ctx.store(f"my_plugin_{ctx.dataset._doc.id}")
+        store = ctx.store(f"my_plugin_{ctx.dataset.name}")
         return {"status": store.get("status") or "idle"}
 ```
 
@@ -145,7 +145,7 @@ class ProcessingOperator(foo.Operator):
 
     def execute(self, ctx):
         plugin_name = self.config.name.split("/")[-1]
-        store = ctx.store(f"{plugin_name}_{ctx.dataset._doc.id}")
+        store = ctx.store(f"{plugin_name}_{ctx.dataset.name}")
 
         total = len(ctx.target_view())
         for i, sample in enumerate(ctx.target_view()):
@@ -485,7 +485,7 @@ class ProcessorPanel(Panel):
         )
 
     def on_load(self, ctx):
-        store = ctx.store(f"processor_{ctx.dataset._doc.id}")
+        store = ctx.store(f"processor_{ctx.dataset.name}")
         ctx.panel.set_data("status", store.get("status") or "idle")
 
     def render(self, ctx):

--- a/skills/fiftyone-develop-plugin/PYTHON-OPERATOR.md
+++ b/skills/fiftyone-develop-plugin/PYTHON-OPERATOR.md
@@ -1,6 +1,8 @@
 # Python Operator Development
 
 ## Contents
+- [Scope](#scope)
+- [How Operators Work](#how-operators-work)
 - [Operator Anatomy](#operator-anatomy)
 - [OperatorConfig Options](#operatorconfig-options)
 - [Execution Context](#execution-context-ctx)
@@ -10,8 +12,40 @@
 - [Using Execution Store](#using-execution-store)
 - [Output Display](#output-display)
 - [Placement (UI Buttons)](#placement-ui-buttons)
+- [Boundary System](#boundary-system)
 - [Debugging Operators](#debugging-operators)
 - [Complete Example](#complete-example-label-exporter)
+
+---
+
+## Scope
+
+**This file covers:** Python operators using `foo.Operator` — input forms, execution logic, progress reporting, delegated execution, output display, and App placement.
+
+**Out of scope:**
+- Python panels (persistent UI with state) → see [PYTHON-PANEL.md](PYTHON-PANEL.md)
+- JavaScript/TypeScript operators → see [JAVASCRIPT-PANEL.md](JAVASCRIPT-PANEL.md)
+- Plugin structure and registration → see [PLUGIN-STRUCTURE.md](PLUGIN-STRUCTURE.md)
+- Debugging load/render errors → see [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
+
+---
+
+## How Operators Work
+
+An operator is a **request-response unit of work** triggered by the user from the operator browser, a button in the App, or another operator via `ctx.trigger()`.
+
+**Lifecycle:**
+1. User opens operator → `resolve_input(ctx)` builds the input form
+2. User fills form and clicks "Execute" → `execute(ctx)` runs (sync or delegated)
+3. Execution completes → `resolve_output(ctx)` builds the results display
+4. If `dynamic=True`, `resolve_input(ctx)` is re-called after every input change to update dependent fields
+
+**Key design rules:**
+- `resolve_input()` must be **fast and side-effect free** — it runs on every form keystroke when `dynamic=True`
+- `execute()` is where all work happens — reads `ctx.params`, accesses `ctx.dataset`/`ctx.view`, returns a dict
+- `resolve_output()` reads `ctx.results` (the dict returned by `execute()`) to build the display
+- Use `execute_as_generator=True` for long-running operations that need progress updates
+- Use `allow_delegated_execution=True` for operations that should run in the background (minutes to hours)
 
 ---
 
@@ -233,11 +267,16 @@ def resolve_input(self, ctx):
 def resolve_input(self, ctx):
     inputs = types.Object()
 
-    # File upload
+    # File path selector (opens file browser)
     inputs.file(
         "input_file",
+        label="Select File",
+    )
+
+    # File upload with content (content included in ctx.params)
+    inputs.uploaded_file(
+        "upload",
         label="Upload File",
-        types=[".json", ".csv"]  # Allowed extensions
     )
 
     # Directory path
@@ -248,6 +287,37 @@ def resolve_input(self, ctx):
     )
 
     return types.Property(inputs)
+```
+
+### Nested Objects
+
+Use `obj()` to group related fields, and `map()` for arbitrary key-value pairs:
+
+```python
+def resolve_input(self, ctx):
+    inputs = types.Object()
+
+    # Nested group of fields
+    config = inputs.obj("config", label="Model Config", view=types.View())
+    config.str("model_name", label="Model Name")
+    config.float("confidence", label="Confidence", min=0.0, max=1.0, default=0.5)
+    config.bool("use_gpu", label="Use GPU", default=True)
+
+    # Key-value map (e.g. custom metadata)
+    inputs.map(
+        "metadata",
+        key_type=types.String(),
+        value_type=types.String(),
+        label="Custom Metadata"
+    )
+
+    return types.Property(inputs)
+
+# In execute(), access nested values:
+def execute(self, ctx):
+    config = ctx.params.get("config", {})
+    model_name = config.get("model_name")
+    metadata = ctx.params.get("metadata", {})
 ```
 
 ### Dynamic Inputs
@@ -468,13 +538,13 @@ Use `ctx.store()` for persistent data across sessions:
 class CachedOperator(foo.Operator):
     version = "v1"
 
-    def _get_store_key(self, ctx):
-        """Generate unique store key."""
+    def _get_store_key(self):
+        # ctx.store() scopes by dataset_id automatically — just use a plugin-unique name
         plugin_name = self.config.name.split("/")[-1]
-        return f"{plugin_name}_{ctx.dataset._doc.id}_{self.version}"
+        return f"{plugin_name}_v{self.version}"
 
     def execute(self, ctx):
-        store = ctx.store(self._get_store_key(ctx))
+        store = ctx.store(self._get_store_key())
 
         # Check cache
         cache_key = f"result_{hash(str(ctx.params))}"
@@ -603,6 +673,20 @@ def resolve_placement(self, ctx):
 | `HISTOGRAM_ACTIONS` | Histogram panel actions |
 | `MAP_ACTIONS` | Map panel actions |
 
+## Boundary System
+
+| Action | Rule |
+|--------|------|
+| Reading `ctx.dataset`, `ctx.view`, `ctx.params`, `ctx.selected` | **Free** — reads only |
+| Calling `resolve_input()`, `resolve_output()`, `resolve_placement()` | **Free** — display only |
+| Writing sample fields, tagging samples, running model inference | **Confirm first** — data mutation |
+| `fo.delete_dataset()`, dropping indexes, overwriting labels without backup | **Never** without explicit user confirmation |
+| Running slow queries inside `resolve_input()` with `dynamic=True` | **Never** — runs on every keystroke |
+
+**Safe testing directive:** Clone the target dataset before testing mutations: `dataset.clone()`. Register the clone under a temporary name so the original is unchanged.
+
+---
+
 ## Debugging Operators
 
 ### Running Server for Logs
@@ -656,6 +740,28 @@ def execute(self, ctx):
 
 ## Complete Example: Label Exporter
 
+All files needed to run this plugin:
+
+**fiftyone.yml**
+```yaml
+name: "@myorg/label-exporter"
+version: "1.0.0"
+description: "Export sample labels to a JSON file"
+fiftyone:
+  version: ">=0.23"
+operators:
+  - export_labels
+```
+
+**Directory layout:**
+```
+~/.fiftyone/plugins/
+└── myorg_label_exporter/
+    ├── fiftyone.yml
+    └── __init__.py
+```
+
+**__init__.py**
 ```python
 import fiftyone.operators as foo
 import fiftyone.operators.types as types

--- a/skills/fiftyone-develop-plugin/PYTHON-PANEL.md
+++ b/skills/fiftyone-develop-plugin/PYTHON-PANEL.md
@@ -1,14 +1,68 @@
 # Python Panel Development
 
 ## Contents
+- [Scope](#scope)
+- [How Panels Work](#how-panels-work)
 - [Panel Anatomy](#panel-anatomy)
 - [PanelConfig Options](#panelconfig-options)
 - [State vs Data vs Store](#state-vs-data-vs-store)
+- [State Anti-Patterns](#state-anti-patterns)
 - [UI Components Reference](#ui-components-reference)
 - [Event Handlers](#event-handlers)
 - [Triggering Operators](#triggering-operators)
 - [Using Execution Store](#using-execution-store)
+- [Boundary System](#boundary-system)
 - [Complete Example](#complete-example-sample-statistics-panel)
+
+---
+
+## Scope
+
+**This file covers:** Python-only panels using `foo.Panel` — the render cycle, state management, event handlers, UI components, layout containers, Plotly charts, and the execution store.
+
+**Out of scope:**
+- React/TypeScript panels with custom components → see [JAVASCRIPT-PANEL.md](JAVASCRIPT-PANEL.md)
+- Hybrid panels (Python backend + React frontend) → see [HYBRID-PLUGINS.md](HYBRID-PLUGINS.md)
+- Non-panel operators (forms, dialogs) → see [PYTHON-OPERATOR.md](PYTHON-OPERATOR.md)
+
+---
+
+## How Panels Work
+
+A panel is a **server-side state machine** rendered by the FiftyOne App on demand.
+
+**Render cycle:**
+1. User opens panel or triggers an event (click, input change, view change)
+2. Python `render(ctx)` is called on the server
+3. `render()` returns a JSON schema describing the UI (`types.Property(panel)`)
+4. SchemaIO (client) renders MUI components from the schema
+5. User interacts → another call to `render(ctx)` → repeat
+
+**What this means in practice:**
+- `render()` runs on every interaction — keep it fast; do not run dataset queries inside it
+- Initialize state in `on_load()` or `on_change_*` handlers; read it in `render()` via `ctx.panel.get_state()`
+- `default=` in the schema is part of the JSON sent to the client on every render. If `default=` reads from state and state changes, the schema changes, triggering another render call — causing an infinite loop. See [State Anti-Patterns](#state-anti-patterns).
+
+**Handler binding rule (critical):**
+`on_click` and `on_change` must be **bound instance methods** — `self.method_name`. The framework reads `handler.__self__` to build the handler URI at schema definition time. `@staticmethod` and bare function references have no `__self__` — they silently produce broken event wiring with no error message.
+
+```python
+# CORRECT — bound instance method
+panel.btn("run", label="Run", on_click=self.on_run)
+
+# WRONG — @staticmethod has no __self__, button silently does nothing
+@staticmethod
+def on_run(ctx): ...
+panel.btn("run", label="Run", on_click=MyPanel.on_run)  # broken, no error
+```
+
+**Three storage mechanisms at a glance:**
+
+| Storage | Set | Read back from Python | Survives reload |
+|---------|-----|----------------------|-----------------|
+| `ctx.panel.set_state("key", val)` | In any handler | Yes, `get_state("key")` | No |
+| `ctx.panel.set_data("key", val)` | In any handler | No (client-side only) | No |
+| `ctx.store("ns").set("key", val)` | In any handler | Yes, `store.get("key")` | Yes |
 
 ---
 
@@ -48,13 +102,12 @@ class MyPanel(foo.Panel):
         """React to view changes (optional)"""
         pass
 
-    def on_change_selection(self, ctx):
+    def on_change_selected(self, ctx):
         """React to selection changes (optional)"""
         pass
 
     def on_custom_event(self, ctx):
         """Custom event handler"""
-        # Define your own events
         pass
 
     def render(self, ctx):
@@ -118,7 +171,7 @@ def on_load(self, ctx):
 def render(self, ctx):
     panel = types.Object()
     count = ctx.panel.get_state("counter", 0)
-    panel.str("display", default=f"Count: {count}")
+    panel.md(f"**Count:** {count}", name="count_display")  # display-only
     return types.Property(panel)
 ```
 
@@ -129,7 +182,6 @@ def render(self, ctx):
 
 ```python
 def on_load(self, ctx):
-    # Store plot data with set_data
     ctx.panel.set_data("my_plot", {
         "data": [{"x": [1, 2, 3], "y": [4, 5, 6], "type": "scatter"}],
         "layout": {"title": "My Plot"}
@@ -137,10 +189,96 @@ def on_load(self, ctx):
 
 def render(self, ctx):
     panel = types.Object()
-    # Reference stored data with data_key
     panel.view("my_plot", types.PlotlyView(data_key="my_plot"))
     return types.Property(panel)
 ```
+
+---
+
+## State Anti-Patterns
+
+### Render loop: `default=` from state
+
+`default=` is part of the schema emitted by `render()`. If `default=` reads from state, the schema changes after every `set_state()` call, which triggers another render, which reads updated state, which changes the schema again — an infinite loop.
+
+```python
+# WRONG — causes infinite render loop
+def render(self, ctx):
+    panel = types.Object()
+    panel.str("name", default=ctx.panel.get_state("name", ""))  # schema changes every render
+    return types.Property(panel)
+```
+
+```python
+# CORRECT — use default= for static values only; display dynamic state as markdown
+def render(self, ctx):
+    panel = types.Object()
+    panel.str("name", label="Name")  # input — static default (empty string)
+    name = ctx.panel.get_state("name", "")
+    if name:
+        panel.md(f"**Current:** {name}", name="name_display")  # display-only, no default
+    return types.Property(panel)
+```
+
+### Unconditional `on_load()` state reset
+
+`on_load()` fires every time the panel opens — including when the user switches datasets and the panel re-opens. Resetting state unconditionally overwrites any state restored from store or set by a prior handler.
+
+```python
+# WRONG — resets every field on every panel open
+def on_load(self, ctx):
+    ctx.panel.set_state("threshold", 0.5)  # wipes user's last value
+    ctx.panel.set_state("selected_field", None)
+```
+
+```python
+# CORRECT — guard: only initialize if not already set
+def on_load(self, ctx):
+    if ctx.panel.get_state("threshold") is None:
+        ctx.panel.set_state("threshold", 0.5)
+    if ctx.panel.get_state("selected_field") is None:
+        ctx.panel.set_state("selected_field", None)
+```
+
+If you use the execution store to persist config across sessions, restore it in `on_load()` before the guard check so the stored value wins over the default:
+
+```python
+def on_load(self, ctx):
+    store = ctx.store(self._get_store_key(ctx))
+    saved = store.get("config")
+    if saved:
+        ctx.panel.set_state("config", saved)
+    elif ctx.panel.get_state("config") is None:
+        ctx.panel.set_state("config", {"threshold": 0.5})
+```
+
+### Querying inside `render()`
+
+`render()` is called on every interaction. A dataset query inside it runs on every keystroke and click.
+
+```python
+# WRONG — runs a database query on every render
+def render(self, ctx):
+    count = len(ctx.view)  # query on every render
+    panel.md(f"**Samples:** {count}", name="count_display")
+```
+
+```python
+# CORRECT — query in lifecycle handlers; store result in state
+def on_load(self, ctx):
+    ctx.panel.set_state("count", len(ctx.view))
+
+def on_change_view(self, ctx):
+    ctx.panel.set_state("count", len(ctx.view))
+
+def render(self, ctx):
+    panel = types.Object()
+    count = ctx.panel.get_state("count", 0)
+    panel.md(f"**Samples:** {count}", name="count_display")
+    return types.Property(panel)
+```
+
+---
 
 ## UI Components Reference
 
@@ -150,17 +288,17 @@ def render(self, ctx):
 def render(self, ctx):
     panel = types.Object()
 
-    # Simple text
-    panel.str("label", default="Static text")
+    # Inline markdown — preferred shorthand for display text
+    panel.md("**Bold** and *italic* text", name="intro")
 
-    # Markdown
+    # Markdown via str + view (verbose but equivalent)
     panel.str(
         "markdown_content",
         view=types.MarkdownView(),
         default="**Bold** and *italic* text"
     )
 
-    # Header
+    # Section header
     panel.str(
         "header",
         view=types.Header(),
@@ -245,26 +383,34 @@ def render(self, ctx):
 
 ### Layout Containers
 
+`h_stack`, `v_stack`, and `grid` all pass kwargs through to their underlying view class. Key kwargs for all three (via `GridView`):
+
+| Kwarg | Values | Default | Effect |
+|-------|--------|---------|--------|
+| `gap` | int | 1 | Spacing between children |
+| `align_x` | `"left"`, `"center"`, `"right"` | `"left"` | Horizontal alignment |
+| `align_y` | `"top"`, `"center"`, `"bottom"` | `"top"` | Vertical alignment |
+| `variant` | `"paper"`, `"outline"` | None | Visual container style |
+
 ```python
 def render(self, ctx):
     panel = types.Object()
 
-    # Horizontal layout
-    row = panel.h_stack("row1")
-    row.str("left", default="Left")
-    row.str("right", default="Right")
+    # Horizontal layout — label next to a slider (realistic dense example)
+    row = panel.h_stack("threshold_row", gap=2, align_y="center")
+    row.md("**Threshold**", name="threshold_label")
+    row.float("threshold", min=0.0, max=1.0, view=types.SliderView())
 
     # Vertical layout
-    col = panel.v_stack("col1")
-    col.str("top", default="Top")
-    col.str("bottom", default="Bottom")
+    col = panel.v_stack("info_col", gap=1)
+    col.md("**Dataset:** " + ctx.dataset.name, name="ds_name")
+    col.md(f"**Samples:** {ctx.panel.get_state('count', 0)}", name="sample_count")
 
-    # Grid layout
-    grid = panel.grid("grid1", columns=2)
-    grid.str("cell1", default="Cell 1")
-    grid.str("cell2", default="Cell 2")
-    grid.str("cell3", default="Cell 3")
-    grid.str("cell4", default="Cell 4")
+    # 2D grid — components flow into rows automatically
+    grid = panel.grid("actions_grid", gap=2)
+    grid.btn("btn_a", label="Export", icon="download", on_click=self.on_export)
+    grid.btn("btn_b", label="Refresh", icon="refresh", on_click=self.on_refresh)
+    grid.btn("btn_c", label="Reset", icon="undo", on_click=self.on_reset)
 
     return types.Property(panel)
 ```
@@ -277,25 +423,74 @@ def render(self, ctx):
 def render(self, ctx):
     panel = types.Object()
 
-    # Plotly chart (requires data set via set_data)
-    # Use panel.view() with PlotlyView for charts
-    panel.view(
-        "chart",
-        types.PlotlyView(data_key="chart_data")
-    )
+    # Plotly chart (data must be set via set_data before render is called)
+    panel.view("chart", types.PlotlyView(data_key="chart_data"))
 
-    # For displaying file paths or sample info, use markdown
+    # Display file info as markdown (panel.image() does not exist)
     filepath = ctx.panel.get_state("filepath", "")
     if filepath:
         import os
-        panel.str(
-            "file_info",
-            view=types.MarkdownView(),
-            default=f"**File:** `{os.path.basename(filepath)}`"
-        )
+        panel.md(f"**File:** `{os.path.basename(filepath)}`", name="file_info")
 
     return types.Property(panel)
 ```
+
+### Plotly Click Events (click-to-filter)
+
+Use `panel.plot()` instead of `panel.view()` when you need click or selection handlers. Pass `on_click` and/or `on_selected` as bound methods — they follow the same binding rule as buttons.
+
+```python
+def on_load(self, ctx):
+    ctx.panel.set_data("label_dist", {
+        "data": [{"x": ["car", "person", "bike"], "y": [40, 25, 15], "type": "bar",
+                  "ids": ["car", "person", "bike"]}],
+        "layout": {"title": "Label Distribution"}
+    })
+
+def on_bar_click(self, ctx):
+    # ctx.params contains: x, y, id, trace, trace_idx, idx, shift_pressed
+    label = ctx.params.get("x")
+    if label:
+        # Filter the view to samples containing this label
+        ctx.ops.set_view(
+            ctx.view.filter_labels("ground_truth", F("label") == label)
+        )
+
+def on_bar_selected(self, ctx):
+    # ctx.params["data"] is a list of selected points, each with x, y, id, trace_idx, idx
+    selected_labels = [p["x"] for p in ctx.params.get("data", [])]
+    if selected_labels:
+        ctx.ops.set_view(
+            ctx.view.filter_labels("ground_truth", F("label").is_in(selected_labels))
+        )
+
+def render(self, ctx):
+    panel = types.Object()
+    # Use panel.plot() (not panel.view()) to attach event handlers
+    panel.plot(
+        "label_dist",
+        on_click=self.on_bar_click,
+        on_selected=self.on_bar_selected,
+        data_key="label_dist"
+    )
+    return types.Property(panel)
+```
+
+**Click handler params available in `ctx.params`:**
+
+| Key | Value |
+|-----|-------|
+| `x` | x value of the clicked point |
+| `y` | y value of the clicked point |
+| `id` | `data.ids[idx]` — use this to store stable IDs |
+| `trace` | `data[trace_idx].name` |
+| `trace_idx` | index of the trace |
+| `idx` | index within the trace |
+| `shift_pressed` | bool — whether Shift was held |
+
+For `on_selected`, `ctx.params["data"]` is a list of the above dicts for each selected point.
+
+**Note:** `ctx.ops.set_view()` takes a FiftyOne view object. Use `from fiftyone import ViewField as F` for filter expressions.
 
 **Limitations:**
 - `panel.media()`, `panel.image()`, `panel.table()` do NOT exist
@@ -306,6 +501,8 @@ def render(self, ctx):
 
 ### Built-in Events
 
+All officially supported event handlers (source: `panel.py`):
+
 ```python
 def on_load(self, ctx):
     """Called when panel opens"""
@@ -315,18 +512,40 @@ def on_unload(self, ctx):
     """Called when panel closes"""
     pass
 
+def on_change(self, ctx):
+    """Called on any context change"""
+    pass
+
 def on_change_ctx(self, ctx):
     """Called when App context changes (dataset, view, selection)"""
     ctx.panel.set_state("dataset_name", ctx.dataset.name)
+
+def on_change_dataset(self, ctx):
+    """Called when the active dataset changes"""
+    pass
 
 def on_change_view(self, ctx):
     """Called when view changes"""
     ctx.panel.set_state("view_count", len(ctx.view))
 
-def on_change_selection(self, ctx):
+def on_change_selected(self, ctx):
     """Called when sample selection changes"""
     ctx.panel.set_state("selected_count", len(ctx.selected))
+
+def on_change_selected_labels(self, ctx):
+    """Called when label selection changes"""
+    pass
+
+def on_change_current_sample(self, ctx):
+    """Called when the current sample in modal changes"""
+    pass
+
+def on_change_spaces(self, ctx):
+    """Called when panel layout spaces change"""
+    pass
 ```
+
+> **Note:** The handler is `on_change_selected`, not `on_change_selection`.
 
 ### Custom Events
 
@@ -338,7 +557,6 @@ def on_button_click(self, ctx):
 
 def on_input_change(self, ctx):
     """Custom change handler"""
-    # Get the new value from the event
     value = ctx.params.get("value")
     ctx.panel.set_state("input_value", value)
 
@@ -373,27 +591,26 @@ Store data beyond panel lifetime with namespaced keys:
 class MyPanel(foo.Panel):
     version = "v1"
 
-    def _get_store_key(self, ctx):
-        """Generate unique store key to avoid cross-dataset conflicts."""
+    def _get_store_key(self):
+        # ctx.store() scopes by dataset_id automatically — just use a plugin-unique name
         plugin_name = self.config.name.split("/")[-1]
-        return f"{plugin_name}_{ctx.dataset._doc.id}_{self.version}"
+        return f"{plugin_name}_v{self.version}"
 
     def on_load(self, ctx):
-        store = ctx.store(self._get_store_key(ctx))
+        store = ctx.store(self._get_store_key())
 
-        # Restore persistent config
         saved_config = store.get("user_config")
         if saved_config:
-            ctx.panel.state.config = saved_config
+            ctx.panel.set_state("config", saved_config)
         else:
-            ctx.panel.state.config = {"default": True}
+            ctx.panel.set_state("config", {"default": True})
 
     def on_save_config(self, ctx):
-        store = ctx.store(self._get_store_key(ctx))
-        store.set("user_config", ctx.panel.state.config)
+        store = ctx.store(self._get_store_key())
+        store.set("user_config", ctx.panel.get_state("config"))
 
     def on_change_dataset(self, ctx):
-        # Reinitialize when dataset changes (store key changes)
+        # Reinitialize when dataset changes (store is scoped per dataset by the framework)
         self.on_load(ctx)
 ```
 
@@ -412,8 +629,49 @@ store.list_keys()                 # Returns list of keys
 
 See [EXECUTION-STORE.md](EXECUTION-STORE.md) for advanced caching patterns.
 
+---
+
+## Boundary System
+
+| Action | Rule |
+|--------|------|
+| Reading dataset schema, listing fields, reading state | **Free** — safe reads |
+| Calling `ctx.panel.set_state()` / `set_data()` / `ctx.store().set()` | **Free** — standard panel operations |
+| Running `len(ctx.view)` or other queries | **Free in handlers** — never inside `render()` |
+| Tagging samples, adding fields, modifying label values | **Confirm first** — data mutation |
+| `fo.delete_dataset()`, dropping indexes, overwriting labels without backup | **Never from a panel** |
+| Running dataset queries inside `render()` | **Never** — runs on every interaction |
+
+**Safe testing directive:** Clone the target dataset before testing mutations: `dataset.clone()`.
+
+---
+
 ## Complete Example: Sample Statistics Panel
 
+Demonstrates: lifecycle hooks, state management, layout containers, Plotly chart, field selector, `register(p)`.
+
+All files needed to run this plugin:
+
+**fiftyone.yml**
+```yaml
+name: "@myorg/sample-statistics"
+version: "1.0.0"
+description: "Panel showing label distribution for the current view"
+fiftyone:
+  version: ">=0.23"
+panels:
+  - statistics_panel
+```
+
+**Directory layout:**
+```
+~/.fiftyone/plugins/
+└── myorg_sample_statistics/
+    ├── fiftyone.yml
+    └── __init__.py
+```
+
+**__init__.py**
 ```python
 import fiftyone.operators as foo
 import fiftyone.operators.types as types
@@ -430,22 +688,16 @@ class StatisticsPanel(foo.Panel):
         )
 
     def on_load(self, ctx):
-        """Initialize panel"""
         self._update_stats(ctx)
 
     def on_change_view(self, ctx):
-        """Update stats when view changes"""
         self._update_stats(ctx)
 
     def _update_stats(self, ctx):
-        """Calculate and store statistics"""
         view = ctx.view
-
-        # Basic counts
         total_samples = len(view)
         ctx.panel.set_state("total_samples", total_samples)
 
-        # Get label field stats if available
         label_counts = {}
         schema = ctx.dataset.get_field_schema()
 
@@ -457,68 +709,47 @@ class StatisticsPanel(foo.Panel):
 
         ctx.panel.set_state("label_counts", label_counts)
 
-        # Create plot data
         if label_counts:
             first_field = list(label_counts.keys())[0]
-            counts = label_counts[first_field]
-            plot_data = {
-                "data": [{
-                    "x": list(counts.keys()),
-                    "y": list(counts.values()),
-                    "type": "bar"
-                }],
-                "layout": {
-                    "title": f"Label Distribution ({first_field})",
-                    "xaxis": {"title": "Label"},
-                    "yaxis": {"title": "Count"}
-                }
+            self._set_plot(ctx, first_field, label_counts[first_field])
+
+    def _set_plot(self, ctx, field_name, counts):
+        ctx.panel.set_data("label_plot", {
+            "data": [{
+                "x": list(counts.keys()),
+                "y": list(counts.values()),
+                "type": "bar"
+            }],
+            "layout": {
+                "title": f"Label Distribution ({field_name})",
+                "xaxis": {"title": "Label"},
+                "yaxis": {"title": "Count"}
             }
-            ctx.panel.set_data("label_plot", plot_data)
+        })
 
     def on_refresh(self, ctx):
-        """Manual refresh button"""
         self._update_stats(ctx)
 
     def on_field_change(self, ctx):
-        """Handle field selection change"""
         selected_field = ctx.params.get("value")
         label_counts = ctx.panel.get_state("label_counts", {})
-
         if selected_field in label_counts:
-            counts = label_counts[selected_field]
-            plot_data = {
-                "data": [{
-                    "x": list(counts.keys()),
-                    "y": list(counts.values()),
-                    "type": "bar"
-                }],
-                "layout": {
-                    "title": f"Label Distribution ({selected_field})",
-                    "xaxis": {"title": "Label"},
-                    "yaxis": {"title": "Count"}
-                }
-            }
-            ctx.panel.set_data("label_plot", plot_data)
+            self._set_plot(ctx, selected_field, label_counts[selected_field])
 
     def render(self, ctx):
         panel = types.Object()
 
-        # Header
-        panel.str(
-            "header",
-            view=types.Header(),
-            default="Dataset Statistics"
-        )
+        # Header row: title + refresh button side by side
+        header_row = panel.h_stack("header_row", align_y="center", gap=2)
+        header_row.str("title", view=types.Header(), default="Dataset Statistics")
+        header_row.btn("refresh_btn", label="Refresh", icon="refresh",
+                       on_click=self.on_refresh)
 
-        # Sample count
+        # Stats row
         total = ctx.panel.get_state("total_samples", 0)
-        panel.str(
-            "count_display",
-            view=types.MarkdownView(),
-            default=f"**Total Samples:** {total}"
-        )
+        panel.md(f"**Total Samples:** {total}", name="count_display")
 
-        # Field selector
+        # Field selector + plot
         label_counts = ctx.panel.get_state("label_counts", {})
         if label_counts:
             panel.enum(
@@ -527,17 +758,10 @@ class StatisticsPanel(foo.Panel):
                 label="Label Field",
                 on_change=self.on_field_change
             )
-
-            # Plot (using view with PlotlyView)
             panel.view("label_plot", types.PlotlyView(data_key="label_plot"))
-
-        # Refresh button
-        panel.btn(
-            "refresh_btn",
-            label="Refresh Statistics",
-            icon="refresh",
-            on_click=self.on_refresh
-        )
+        else:
+            panel.md("*No detection fields found in this dataset.*",
+                     name="no_data_msg")
 
         return types.Property(panel)
 

--- a/skills/fiftyone-develop-plugin/QUICK-REFERENCE.md
+++ b/skills/fiftyone-develop-plugin/QUICK-REFERENCE.md
@@ -1,0 +1,158 @@
+# Quick Reference
+
+Lookup tables and a minimal working example. Read this when you need to check a type, option name, or want a copy-pasteable starting point.
+
+---
+
+## Plugin Types
+
+| Type | Language | Use Case |
+|------|----------|----------|
+| Operator | Python | Data processing, computations, form-based actions |
+| Panel | Python-only (default) | Persistent UI — prefer this unless rich React components are needed |
+| Panel | Hybrid | Python backend + React frontend — only when Python UI is insufficient |
+
+---
+
+## Operator Config Options
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `dynamic` | False | Recalculate inputs on change (runs `resolve_input` on every keystroke — keep it fast) |
+| `execute_as_generator` | False | Stream progress updates with `yield` |
+| `allow_immediate_execution` | True | Execute in foreground |
+| `allow_delegated_execution` | False | Allow background execution |
+| `default_choice_to_delegated` | False | Default to background when both modes are allowed |
+| `unlisted` | False | Hide from operator browser |
+| `on_startup` | False | Execute when App starts |
+| `on_dataset_open` | False | Execute when a dataset is opened |
+
+---
+
+## Panel Config Options
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `surfaces` | `"grid"` | Where panel can display: `"grid"`, `"modal"`, `"grid modal"` |
+| `allow_multiple` | False | Allow multiple instances of the panel |
+| `category` | None | Panel category in browser |
+| `priority` | None | Sort order in UI |
+| `unlisted` | False | Hide from panel browser |
+
+---
+
+## Input Types (Operators)
+
+| Type | Method | Notes |
+|------|--------|-------|
+| Text | `inputs.str()` | |
+| Integer | `inputs.int(min=..., max=...)` | |
+| Float | `inputs.float(min=..., max=...)` | |
+| Boolean | `inputs.bool()` | Renders as checkbox |
+| Dropdown | `inputs.enum(values=[...])` | |
+| Radio buttons | `inputs.enum(values=[...], view=types.RadioGroup())` | |
+| File selector | `inputs.file()` | |
+| File upload | `inputs.uploaded_file()` | Content included in `ctx.params` |
+| View target | `inputs.view_target(ctx)` | Dataset / current view / selected samples selector |
+| Nested object | `inputs.obj(name)` | Returns sub-Object; access as `ctx.params["name"]` dict |
+| List | `inputs.list(name, element_type)` | e.g., `inputs.list("tags", types.String())` |
+| Key-value map | `inputs.map(name, key_type, value_type)` | |
+| Directory path | `inputs.str(name, view=types.DirectoryView())` | |
+
+---
+
+## Panel UI Components
+
+All methods live on the `types.Object()` returned from `render()`. Use `h_stack`/`v_stack`/`grid` — agents default to vertical stacking, which produces poor layouts.
+
+| Component | Method | Notes |
+|-----------|--------|-------|
+| Text input | `panel.str()` | |
+| Number input | `panel.int()` / `panel.float(min=..., max=...)` | |
+| Checkbox | `panel.bool()` | |
+| Dropdown | `panel.enum(values=[...])` | |
+| Button | `panel.btn(label=..., on_click=self.handler)` | handler must be bound instance method |
+| Markdown display | `panel.md("**text**")` | shorthand; use for display-only labels |
+| Plotly chart (display) | `panel.view("key", types.PlotlyView(data_key="key"))` | data set via `ctx.panel.set_data()` |
+| Plotly chart (interactive) | `panel.plot("key", on_click=self.handler, data_key="key")` | use when you need click/select events |
+| Horizontal row | `panel.h_stack("row")` → sub-Object | children laid out left→right |
+| Vertical column | `panel.v_stack("col")` → sub-Object | children laid out top→bottom |
+| 2D grid | `panel.grid("g")` → sub-Object | use `gap`, `align_x`, `align_y` kwargs |
+
+**Dense layout example** (slider next to label — the pattern agents get wrong most often):
+
+```python
+def render(self, ctx):
+    panel = types.Object()
+    row = panel.h_stack("threshold_row")
+    row.md("**Threshold**", name="threshold_label")   # md() for display-only label
+    row.float("threshold", min=0.0, max=1.0, view=types.SliderView())
+    return types.Property(panel)
+```
+
+> **`LabelValueView` restriction:** Read-only display of existing values only — unsupported on input properties like `str()` or `float()`. Use `panel.md()` for inline labels next to inputs instead.
+
+See [PYTHON-PANEL.md](PYTHON-PANEL.md#layout-containers) for full layout reference including GridView kwargs.
+
+---
+
+## Minimal Working Example
+
+The smallest complete plugin. Use this as a copy-paste starting point.
+
+**Directory layout:**
+```
+~/.fiftyone/plugins/
+└── myorg_hello_world/          ← directory name: underscores, no @ or -
+    ├── fiftyone.yml
+    └── __init__.py
+```
+
+**fiftyone.yml:**
+```yaml
+name: "@myorg/hello-world"
+version: "1.0.0"
+description: "Hello world operator"
+fiftyone:
+  version: ">=0.23"
+operators:
+  - hello_world
+```
+
+> **URI vs directory name:** The `@myorg/hello-world` URI lives only inside `fiftyone.yml`. The directory just needs to contain that file — its name doesn't need to match. `_to_python_safe_name()` derives the module name from the YAML `name:` field, not the directory.
+
+**__init__.py:**
+```python
+import fiftyone.operators as foo
+import fiftyone.operators.types as types
+
+
+class HelloWorld(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="hello_world",
+            label="Hello World"
+        )
+
+    def resolve_input(self, ctx):
+        inputs = types.Object()
+        inputs.str("message", label="Message", default="Hello!")
+        return types.Property(inputs)
+
+    def execute(self, ctx):
+        print(ctx.params["message"])
+        return {"status": "done"}
+
+
+def register(p):
+    p.register(HelloWorld)
+```
+
+**Install and test:**
+```bash
+PLUGINS_DIR=$(python -c "import fiftyone as fo; print(fo.config.plugins_dir)")
+ln -s /path/to/myorg_hello_world "$PLUGINS_DIR/myorg_hello_world"
+fiftyone app debug
+# Open operator browser → search "Hello World"
+```

--- a/skills/fiftyone-develop-plugin/SKILL.md
+++ b/skills/fiftyone-develop-plugin/SKILL.md
@@ -5,6 +5,43 @@ description: Develops custom FiftyOne plugins (operators and panels) from scratc
 
 # Develop FiftyOne Plugins
 
+## TL;DR — Read This First
+
+**Step 1: Decide what you're building.**
+
+| Goal | Type | Read next |
+|------|------|-----------|
+| Run a computation, process samples, trigger actions | **Operator** | [PYTHON-OPERATOR.md](PYTHON-OPERATOR.md) |
+| Persistent panel in the grid, simple/form UI | **Python Panel** | [PYTHON-PANEL.md](PYTHON-PANEL.md) |
+| Persistent panel in the grid, rich/interactive UI | **Hybrid Panel** | [HYBRID-PLUGINS.md](HYBRID-PLUGINS.md) + [JAVASCRIPT-PANEL.md](JAVASCRIPT-PANEL.md) |
+| Panel that opens inside the sample modal | **JS Modal Panel** | [JAVASCRIPT-PANEL.md](JAVASCRIPT-PANEL.md) |
+
+**Step 2: Read that file NOW — before generating any code.** Each file contains patterns that are not in SKILL.md. Missing them causes the most common failures (wrong `default=` usage, handler binding errors, panel not appearing in App).
+
+**If something isn't rendering or you hit an error:** Read [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for the one-shot diagnostic command, reload vs restart table, and the top 5 error patterns with exact fixes.
+
+**For input types, Panel UI components reference, and a minimal working example:** Read [QUICK-REFERENCE.md](QUICK-REFERENCE.md).
+
+**Step 3: Clone the official plugins repo for reference patterns:**
+```bash
+git clone https://github.com/voxel51/fiftyone-plugins.git /tmp/fiftyone-plugins 2>/dev/null || true
+```
+
+**Step 4: Install your plugin by placing it (or symlinking it) in the plugins directory:**
+```bash
+PLUGINS_DIR=$(python -c "import fiftyone as fo; print(fo.config.plugins_dir)")
+# Convention: use underscores in the directory name (e.g. myorg_my_plugin) for shell compatibility
+# The @org/name URI lives only inside fiftyone.yml — the directory name doesn't need to match
+ln -s /path/to/my_plugin "$PLUGINS_DIR/my_plugin"
+```
+
+**Step 5: Launch in debug mode so you see all server logs:**
+```bash
+fiftyone app debug <dataset-name>
+```
+
+---
+
 ## Key Directives
 
 **ALWAYS follow these rules:**
@@ -46,7 +83,24 @@ Write tests:
 
 Verify in FiftyOne App before done.
 
-### 5. Iterate on feedback
+### 5. Test complex logic outside the plugin first
+
+If the plugin wraps non-trivial processing (model inference, image transforms, external APIs), verify that logic works as standalone Python before integrating it into the plugin:
+
+```python
+# Test independently first
+result = my_processing_fn(sample_path)
+print(result)  # confirm correctness
+
+# Only then wrap in execute()
+def execute(self, ctx):
+    result = my_processing_fn(ctx.dataset.first().filepath)
+    ...
+```
+
+This prevents debugging two systems (plugin framework + custom logic) at once.
+
+### 6. Iterate on feedback
 
 Run server separately to see logs:
 ```bash
@@ -70,6 +124,65 @@ Refine until the plugin works as expected.
 
 ## Critical Patterns
 
+### Gotcha 1 — `default=` must never reference state (causes infinite render loops)
+
+```python
+# WRONG — triggers a render loop: schema changes → re-render → schema changes → ...
+def render(self, ctx):
+    panel = types.Object()
+    panel.str("threshold", default=ctx.panel.get_state("threshold"))  # ← NEVER do this
+
+# CORRECT — pass a literal; read state separately for display logic
+def render(self, ctx):
+    panel = types.Object()
+    panel.str("threshold", default="0.5")  # literal only
+    current = ctx.panel.get_state("threshold", "0.5")  # read separately if needed
+```
+
+The `default=` value is part of the schema the frontend uses to decide whether to re-render. If it changes between renders (because state changed), the frontend re-dispatches, which re-renders, infinitely.
+
+### Gotcha 2 — Event handlers must be bound instance methods, not static methods
+
+```python
+# WRONG — @staticmethod strips __self__, breaking the handler URI silently
+@staticmethod
+def on_click(ctx):
+    ...
+
+panel.btn("btn", label="Go", on_click=MyPanel.on_click)  # ← broken
+
+# CORRECT — regular instance method
+def on_click(self, ctx):
+    ...
+
+panel.btn("btn", label="Go", on_click=self.on_click)  # ← works
+```
+
+The framework reads `handler.__self__.uri` to build the operator-trigger URI. A `@staticmethod` has no `__self__`, so the wiring silently fails and button clicks do nothing.
+
+### Gotcha 3 — Missing `register(p)` is a silent failure
+
+```python
+# WRONG — plugin loads, no error, but ZERO operators appear in the App
+import fiftyone.operators as foo
+
+class MyPanel(foo.Panel):
+    ...
+
+# forgot register() entirely — or it raises an exception silently
+```
+
+```python
+# CORRECT — must explicitly register every operator and panel
+def register(p):
+    p.register(MyPanel)
+    p.register(MyOperator)  # each class must be listed
+```
+
+The plugin loader calls `module.register(self)` after importing `__init__.py`. If the function is missing, raises an exception, or simply doesn't call `p.register(YourClass)` for a class, that class is never inserted into the operator registry. The App shows the plugin as **enabled** in `list_plugins()` — no error, no warning — but the operator or panel is completely invisible. This is the most common cause of "my panel doesn't appear in the + New panel menu."
+
+**Convention on directory naming:** Use `myorg_my_plugin` (underscores, no `@` or `-`) for clarity and shell compatibility. This is convention, not a hard requirement — the loader derives the module name from `fiftyone.yml`'s `name:` field and sanitizes it automatically. The `@org/name` URI belongs in `fiftyone.yml`; the directory just needs to contain that file.
+
 ### Operator Execution
 ```python
 # Chain operators (non-delegated operators only, in execute() only, fire-and-forget)
@@ -77,7 +190,7 @@ ctx.trigger("@plugin/other_operator", params={...})
 
 # UI operations
 ctx.ops.notify("Done!")
-ctx.ops.set_progress(0.5)
+ctx.ops.set_progress(progress=0.5)  # keyword required — first positional arg is label, not progress
 ```
 
 ### View Selection
@@ -92,12 +205,12 @@ view = ctx.target_view()
 
 ### Store Keys (Avoid Collisions)
 ```python
-# Use namespaced keys to avoid cross-dataset conflicts
-def _get_store_key(self, ctx):
-    plugin_name = self.config.name.split("/")[-1]
-    return f"{plugin_name}_store_{ctx.dataset._doc.id}_{self.version}"
+# ctx.store() already scopes by dataset_id internally — no need to embed dataset name.
+# Use a plugin-unique name to avoid collisions with other plugins on the same dataset.
+def _get_store_key(self):
+    return self.config.name.split("/")[-1]  # e.g. "my_panel"
 
-store = ctx.store(self._get_store_key(ctx))
+store = ctx.store(self._get_store_key())
 ```
 
 ### Panel State vs Execution Store
@@ -107,7 +220,7 @@ store = ctx.store(self._get_store_key(ctx))
 
 def on_load(self, ctx):
     ctx.panel.state.selected_tab = "overview"  # Transient
-    store = ctx.store(self._get_store_key(ctx))
+    store = ctx.store(self._get_store_key())
     ctx.panel.state.config = store.get("user_config") or {}  # Persistent
 ```
 
@@ -188,6 +301,17 @@ See [PLUGIN-STRUCTURE.md](PLUGIN-STRUCTURE.md) for file formats.
 
 ### Phase 3: Generate Code
 
+**Before writing any code, read the reference file for your plugin type:**
+
+| Building… | Read this file first |
+|-----------|---------------------|
+| Operator | **[PYTHON-OPERATOR.md](PYTHON-OPERATOR.md)** — input types, execution patterns, placement |
+| Python panel | **[PYTHON-PANEL.md](PYTHON-PANEL.md)** — layout containers, state/data/store, event lifecycle |
+| JS/hybrid panel | **[JAVASCRIPT-PANEL.md](JAVASCRIPT-PANEL.md)** + **[HYBRID-PLUGINS.md](HYBRID-PLUGINS.md)** — React components, Python↔JS bridge |
+| Persistent storage | **[EXECUTION-STORE.md](EXECUTION-STORE.md)** — TTL caching, cross-session state |
+| Something not rendering / errors | **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — one-shot diagnostic, top 5 errors, reload vs restart |
+| Input types, Panel UI components, minimal example | **[QUICK-REFERENCE.md](QUICK-REFERENCE.md)** — lookup tables and copy-paste starting point |
+
 Create these files:
 
 | File | Required | Purpose |
@@ -197,13 +321,6 @@ Create these files:
 | `requirements.txt` | If deps | Python dependencies |
 | `package.json` | JS only | Node.js metadata |
 | `src/index.tsx` | JS only | React components |
-
-Reference docs:
-- [PYTHON-OPERATOR.md](PYTHON-OPERATOR.md) - Python operators
-- [PYTHON-PANEL.md](PYTHON-PANEL.md) - Python panels
-- [JAVASCRIPT-PANEL.md](JAVASCRIPT-PANEL.md) - React/TypeScript panels
-- [HYBRID-PLUGINS.md](HYBRID-PLUGINS.md) - Python + JavaScript communication
-- [EXECUTION-STORE.md](EXECUTION-STORE.md) - Persistent storage and caching
 
 **For JavaScript panels with rich UI**: Invoke the `fiftyone-voodo-design` skill for VOODO components (buttons, inputs, toasts, design tokens). VOODO is FiftyOne's official React component library.
 
@@ -245,144 +362,44 @@ execute_operator(operator_uri="@myorg/my-operator", params={...})
 
 ## Quick Reference
 
-### Plugin Types
+For the full input types table, Panel UI components, config option tables, and a minimal working example:
 
-| Type | Language | Use Case |
-|------|----------|----------|
-| Operator | Python | Data processing, computations |
-| Panel | Hybrid (default) | Python backend + React frontend (recommended) |
-| Panel | Python-only | Simple UI without rich interactivity |
-
-### Operator Config Options
-
-| Option | Default | Effect |
-|--------|---------|--------|
-| `dynamic` | False | Recalculate inputs on change |
-| `execute_as_generator` | False | Stream progress with yield |
-| `allow_immediate_execution` | True | Execute in foreground |
-| `allow_delegated_execution` | False | Background execution |
-| `default_choice_to_delegated` | False | Default to background |
-| `unlisted` | False | Hide from operator browser |
-| `on_startup` | False | Execute when app starts |
-| `on_dataset_open` | False | Execute when dataset opens |
-
-### Panel Config Options
-
-| Option | Default | Effect |
-|--------|---------|--------|
-| `allow_multiple` | False | Allow multiple panel instances |
-| `surfaces` | "grid" | Where panel can display ("grid", "modal", "grid modal") |
-| `category` | None | Panel category in browser |
-| `priority` | None | Sort order in UI |
-
-### Input Types
-
-| Type | Method |
-|------|--------|
-| Text | `inputs.str()` |
-| Number | `inputs.int()` / `inputs.float()` |
-| Boolean | `inputs.bool()` |
-| Dropdown | `inputs.enum()` |
-| File | `inputs.file()` |
-| View | `inputs.view_target()` |
-
-## Minimal Example
-
-**fiftyone.yml:**
-```yaml
-name: "@myorg/hello-world"
-type: plugin
-operators:
-  - hello_world
-```
-
-**__init__.py:**
-```python
-import fiftyone.operators as foo
-import fiftyone.operators.types as types
-
-class HelloWorld(foo.Operator):
-    @property
-    def config(self):
-        return foo.OperatorConfig(
-            name="hello_world",
-            label="Hello World"
-        )
-
-    def resolve_input(self, ctx):
-        inputs = types.Object()
-        inputs.str("message", label="Message", default="Hello!")
-        return types.Property(inputs)
-
-    def execute(self, ctx):
-        print(ctx.params["message"])
-        return {"status": "done"}
-
-def register(p):
-    p.register(HelloWorld)
-```
-
-## Debugging
-
-### Where Logs Go
-
-| Log Type | Location |
-|----------|----------|
-| Python backend | Terminal running the server |
-| JavaScript frontend | Browser console (F12 → Console) |
-| Network requests | Browser DevTools (F12 → Network) |
-| Operator errors | Operator browser in FiftyOne App |
-
-### Running in Debug Mode (Recommended for Development)
-
-```bash
-fiftyone app debug                    # server logs printed to shell
-fiftyone app debug <dataset-name>     # with a dataset pre-loaded
-```
-
-### Python Debugging
-
-```python
-def execute(self, ctx):
-    # Use print() for quick debugging (shows in server terminal)
-    print(f"Params received: {ctx.params}")
-    print(f"View stages: {ctx.view.stages}")           
-    print(f"View pipeline: {ctx.view._pipeline()}")    
-
-    # For structured logging
-    import logging
-    logging.debug(f"View stages: {ctx.target_view().stages}")
-    logging.debug(f"View pipeline: {ctx.target_view()._pipeline()}")
-
-    # ... rest of execution
-```
-
-### JavaScript/TypeScript Debugging
-
-```typescript
-// Use console.log in React components
-console.log("Component state:", state);
-console.log("Panel data:", panelData);
-
-// Check browser DevTools:
-// - Console: JS errors, syntax errors, plugin load failures
-// - Network: API calls, variable values before/after execution
-```
-
-### Common Debug Locations
-
-- **Operator not executing**: Check Network tab for request/response
-- **Plugin not loading**: Check Console for syntax errors
-- **Variables not updating**: Check Network tab for payload data
-- **Silent failures**: Check Operator browser for error messages
+**→ Read [QUICK-REFERENCE.md](QUICK-REFERENCE.md) now.**
 
 ## Troubleshooting
+
+### One-shot plugin load diagnostic
+
+Run this first whenever a plugin or operator is missing from the App:
+
+```bash
+curl -s -X POST http://localhost:5151/operators \
+  -H 'Content-Type: application/json' -d '{}' \
+  | python -c "
+import json, sys
+d = json.load(sys.stdin)
+errors = d.get('errors', [])
+if errors:
+    print('PLUGIN LOAD ERRORS:')
+    for e in errors: print(' -', e)
+else:
+    print('No load errors. Operators found:', len(d.get('operators', [])))
+"
+```
+
+This returns every error the plugin loader captured — Python syntax errors, import failures, missing `register()` calls — in one shot. Check this before debugging anything else.
 
 **Plugin not appearing:**
 - Check `fiftyone.yml` exists in plugin root
 - Verify location: `~/.fiftyone/plugins/`
-- Check for Python syntax errors
+- Check `register(p)` is present and calls `p.register()` for each class — see Gotcha 3 above
+- Check for Python syntax errors (run the diagnostic above)
 - Restart FiftyOne App
+
+**Panel not appearing in the "+ New panel" menu:**
+- Plugin must load cleanly (check diagnostic above)
+- `PanelConfig.name` must match the entry under `panels:` in `fiftyone.yml`
+- Restart App after adding a new panel — the panel registry is built at startup
 
 **Operator not found:**
 - Verify operator listed in `fiftyone.yml`
@@ -392,6 +409,10 @@ console.log("Panel data:", panelData);
 **Secrets not available:**
 - Add to `fiftyone.yml` under `secrets:`
 - Set environment variables before starting FiftyOne
+
+**Render loop / thousands of operator calls per minute:**
+- Almost always caused by `default=ctx.panel.get_state(...)` — see Gotcha 1 above
+- Fix: replace with a string/number literal in `default=`
 
 ## Advanced
 

--- a/skills/fiftyone-develop-plugin/TROUBLESHOOTING.md
+++ b/skills/fiftyone-develop-plugin/TROUBLESHOOTING.md
@@ -1,0 +1,341 @@
+# Troubleshooting FiftyOne Plugins
+
+## Contents
+- [Pre-Flight Check](#pre-flight-check)
+- [One-Shot Plugin Diagnostic](#one-shot-plugin-diagnostic)
+- [Reload vs Restart](#reload-vs-restart)
+- [App Lifecycle](#app-lifecycle)
+- [Top Errors with Exact Fixes](#top-errors-with-exact-fixes)
+- [State and Panel Debugging](#state-and-panel-debugging)
+- [Operator Debugging](#operator-debugging)
+
+---
+
+## Pre-Flight Check
+
+Run these before debugging anything else. Many sessions stall because one of these is false.
+
+```bash
+# 1. Is the App running?
+curl -s http://localhost:5151/operators > /dev/null && echo "App is UP" || echo "App is DOWN — run: python -c \"import fiftyone as fo; fo.launch_app()\""
+
+# 2. Does your plugins directory exist and contain your plugin?
+python3 -c "import fiftyone as fo; print(fo.config.plugins_dir)"
+ls $(python3 -c "import fiftyone as fo; print(fo.config.plugins_dir)")
+
+# 3. Does your plugin directory have a fiftyone.yml?
+ls $(python3 -c "import fiftyone as fo; print(fo.config.plugins_dir)")/YOUR_PLUGIN_DIR/fiftyone.yml
+```
+
+**MCP pre-flight:** If Claude is using MCP tools to interact with the App, verify MCP is active by running `fiftyone__list_plugins` or `fiftyone__get_context_info`. If MCP tools return errors, the App session needs to be started in the same Python environment where FiftyOne is installed — MCP does not work across virtual environments.
+
+---
+
+## One-Shot Plugin Diagnostic
+
+Run this whenever a plugin isn't loading or operators aren't appearing. It returns all Python-level load errors from the plugin registry.
+
+```bash
+curl -s -X POST http://localhost:5151/operators \
+  -H 'Content-Type: application/json' -d '{}' \
+  | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+errors = d.get('errors', [])
+if errors:
+    print('PLUGIN LOAD ERRORS:')
+    for e in errors: print(' -', e)
+else:
+    ops = d.get('operators', [])
+    print(f'No load errors. {len(ops)} operators registered.')
+    for op in ops: print(f'  {op.get(\"name\", \"?\")}')
+"
+```
+
+**What the output means:**
+
+| Output | Meaning |
+|--------|---------|
+| `No load errors. 0 operators registered` | `register(p)` is missing or empty — see Error #2 below |
+| `No load errors. N operators registered` | Plugin loaded. If panel still doesn't show, restart the App |
+| `SyntaxError: ...` | Python syntax error in `__init__.py` — fix it, browser-refresh |
+| `ModuleNotFoundError: ...` | Import failure — check your imports, check `requirements.txt` |
+| `AttributeError: ...` | Likely a mis-named method or wrong API call |
+| Connection refused | App is not running |
+
+---
+
+## Reload vs Restart
+
+The wrong action wastes many prompts. Use this table.
+
+| Change type | What to do |
+|-------------|------------|
+| Python logic change in `execute()` or a handler | Browser hard-refresh (Cmd+Shift+R / Ctrl+Shift+F5) |
+| New operator or panel added to `fiftyone.yml` | **Full App restart** + browser refresh |
+| New operator or panel class added to `__init__.py` | **Full App restart** + browser refresh |
+| JavaScript bundle rebuilt (`npm run build`) | **Full App restart** + browser hard-refresh |
+| `fiftyone.yml` name or version changed | **Full App restart** |
+| Dataset reload (`reload_dataset`) | Only needed when dataset documents change outside Python |
+
+**Full App restart:**
+```python
+# Stop the running session, then:
+import fiftyone as fo
+session = fo.launch_app(dataset)
+```
+
+**Why browser hard-refresh matters for JS:** The App caches the JS bundle. A normal refresh may serve the old bundle even after a restart.
+
+---
+
+## App Lifecycle
+
+### Keeping the App alive from a script
+
+```python
+import fiftyone as fo
+
+dataset = fo.load_dataset("my-dataset")
+session = fo.launch_app(dataset)
+session.wait()  # blocks until the App window is closed — use in standalone scripts
+```
+
+### Safe testing: always clone your dataset
+
+Work on a clone during development to avoid corrupting real data:
+
+```python
+import fiftyone as fo
+
+src = fo.load_dataset("my-real-dataset")
+test_ds = src.clone("my-real-dataset-dev")  # safe copy
+# develop against test_ds; delete when done
+fo.delete_dataset("my-real-dataset-dev")
+```
+
+### Debug logging
+
+```python
+def execute(self, ctx):
+    print(f"Params: {ctx.params}")
+    print(f"View stages: {ctx.view.stages}")
+    print(f"Selected: {ctx.selected}")
+```
+
+Python `print()` output goes to the terminal running the server. Start the server separately to see it:
+
+```bash
+python -m fiftyone.server.main   # Terminal 1 — logs appear here
+fiftyone app debug               # Terminal 2 — or launch with dataset
+```
+
+---
+
+## Top Errors with Exact Fixes
+
+### Error 1: Panel/operator appears in the list but doesn't work
+
+**Symptom:** Operator is visible in the browser, but clicking it does nothing, or panel opens blank.
+
+**Diagnostic:**
+```bash
+# Check for load errors first
+curl -s -X POST http://localhost:5151/operators \
+  -H 'Content-Type: application/json' -d '{}' | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('errors', 'none'))"
+```
+
+**Causes and fixes:**
+- Python syntax error in `__init__.py` → fix the syntax, browser-refresh (no restart needed)
+- `render()` raises an uncaught exception → check server terminal for the traceback
+- Handler method missing or misspelled → check method name (e.g., `on_change_selected` not `on_change_selection`)
+
+---
+
+### Error 2: Plugin loads but zero operators are registered
+
+**Symptom:** `/operators` returns `"No load errors. 0 operators registered."` The plugin is enabled in the App.
+
+**Root cause:** `register(p)` function is missing, empty, or raises silently.
+
+```python
+# WRONG — plugin loads, no error, but ZERO operators appear in the App
+def register(p):
+    pass  # forgot p.register(MyPanel)
+
+# WRONG — register raises silently (e.g. wrong class passed)
+def register(p):
+    p.register(MyPanel())  # passing an instance instead of the class — silent error
+
+# CORRECT
+def register(p):
+    p.register(MyPanel)
+    p.register(MyOperator)
+```
+
+**Fix:** Add or correct `register(p)` at the bottom of `__init__.py`, then browser-refresh (no restart needed for this change).
+
+---
+
+### Error 3: Panel renders once then freezes or keeps re-rendering
+
+**Symptom:** Panel loads once, then interactions produce no response. Or the panel continuously re-renders (spinner loops).
+
+**Root cause A — infinite render loop:** `default=` reads from `ctx.panel.get_state()`. Schema changes each render → re-render → schema changes → infinite loop.
+
+```python
+# WRONG — causes infinite render loop
+panel.str("name", default=ctx.panel.get_state("name", ""))
+
+# CORRECT — use default= for static values only; display state as markdown
+panel.str("name", label="Name")           # input, static default
+name = ctx.panel.get_state("name", "")
+if name:
+    panel.md(f"**Current:** {name}", name="name_display")
+```
+
+**Root cause B — button handler is a static method or unbound function:**
+
+```python
+# WRONG — @staticmethod has no __self__, button silently does nothing
+@staticmethod
+def on_click(ctx): ...
+panel.btn("run", label="Run", on_click=MyPanel.on_click)
+
+# CORRECT
+def on_click(self, ctx): ...
+panel.btn("run", label="Run", on_click=self.on_click)
+```
+
+---
+
+### Error 4: `on_change_*` handler never fires
+
+**Symptom:** You define an `on_change_*` method but it is never called when the expected event occurs.
+
+**Cause:** The method name does not match any registered hook. Common misspellings:
+
+| Wrong | Correct |
+|-------|---------|
+| `on_change_selection` | `on_change_selected` |
+| `on_change_sample` | `on_change_current_sample` |
+| `on_change_labels` | `on_change_selected_labels` |
+
+**Complete list of valid hook names** (from `panel.py`): `on_load`, `on_unload`, `on_change`, `on_change_ctx`, `on_change_dataset`, `on_change_view`, `on_change_spaces`, `on_change_current_sample`, `on_change_selected`, `on_change_selected_labels`, `on_change_extended_selection`, `on_change_group_slice`, `on_change_query_performance`, `on_change_active_fields`.
+
+---
+
+### Error 5: `ctx.current_sample` causes AttributeError
+
+**Symptom:** `AttributeError: 'str' object has no attribute 'filepath'` (or similar) when accessing sample data.
+
+**Root cause:** `ctx.current_sample` is a **string ID**, not a `Sample` object.
+
+```python
+# WRONG
+filepath = ctx.current_sample.filepath  # AttributeError
+
+# CORRECT
+sample_id = ctx.current_sample           # string ID
+sample = ctx.dataset[sample_id]          # fetch the Sample
+filepath = sample.filepath
+```
+
+---
+
+## State and Panel Debugging
+
+### Print state contents
+
+```python
+def on_load(self, ctx):
+    # Print current state to server terminal (panel_state is readable)
+    print(f"=== PANEL STATE: {ctx.panel_state} ===")
+    # Note: panel data is write-only (client-side) — cannot be read back from Python
+```
+
+### Verify store contents
+
+```python
+def on_load(self, ctx):
+    store = ctx.store("my_store")
+    print(f"Store keys: {store.list_keys()}")
+    for key in store.list_keys():
+        print(f"  {key}: {store.get(key)}")
+```
+
+### Isolate render issues
+
+If a panel produces no visible output, add this minimal render to confirm the framework is working, then add components back one by one:
+
+```python
+def render(self, ctx):
+    panel = types.Object()
+    panel.md("**Panel is rendering**", name="debug")
+    return types.Property(panel)
+```
+
+### Check server logs
+
+Always run the FiftyOne server in a terminal where you can see Python output:
+
+```bash
+# Terminal 1: server with visible logs
+python -m fiftyone.server.main
+
+# Terminal 2: launch app (connect to running server)
+python3 -c "import fiftyone as fo; fo.launch_app()"
+```
+
+Python exceptions from `render()`, `execute()`, and event handlers print to the server terminal. Without this, errors are invisible.
+
+---
+
+## Operator Debugging
+
+### Inspect what the operator received
+
+```python
+def execute(self, ctx):
+    print(f"=== {self.config.name} ===")
+    print(f"params: {ctx.params}")
+    print(f"dataset: {ctx.dataset.name}")
+    print(f"view stages: {ctx.view.stages}")
+    print(f"selected: {ctx.selected}")
+    target = ctx.target_view()
+    print(f"target count: {len(target)}")
+```
+
+### Operator not showing in browser
+
+1. Run the one-shot diagnostic — check `errors` key
+2. Verify the operator name in `fiftyone.yml` matches the `name` field in `OperatorConfig`
+3. Restart the App if you added a new operator after the last restart
+4. Check `unlisted=True` is not accidentally set in `OperatorConfig`
+
+### Generator operator hangs
+
+If `execute_as_generator=True` and the operator appears to hang with no progress:
+
+```python
+# Every yield must be a trigger or a dict — not None
+yield ctx.trigger("set_progress", {"progress": 0.5, "label": "..."})  # OK
+yield {"status": "done"}   # OK at the end
+# yield None               # WRONG — breaks the generator
+```
+
+### Delegated operator not running
+
+```python
+# Check if delegation is configured correctly
+@property
+def config(self):
+    return foo.OperatorConfig(
+        name="my_op",
+        allow_delegated_execution=True,
+        allow_immediate_execution=True,  # both flags needed for user choice
+    )
+
+# Check that a delegated executor is running
+# fiftyone delegated launch  (in a separate terminal)
+```


### PR DESCRIPTION
## Hack Day 🎸 

During the FO Agent Hackday, 12 participants built custom plugins using the `fiftyone-develop-plugin` skill and Custom Agents. Participants ranged from first-time FO users to core team engineers.

The findings in this PR come from two sources collected during the hackday: structured participant feedback gathered via survey, and the skill/prompt files generated during each participant session. These were analyzed to identify transversal findings, recurring patterns, failure modes, API misunderstandings, and usability issues that appeared across multiple independent sessions. The findings were then validated against the FiftyOne source code, before being applied as improvements to the skill documentation, examples, and troubleshooting guides, all of this using claude plus me validating it. 

## What changed

### New files

- Added `TROUBLESHOOTING.md`
  - Pre-flight checklist
  - One-shot plugin load diagnostic
  - Reload vs restart guidance
  - Top plugin errors with fixes
  - App lifecycle notes for `session.wait()`, dataset cloning, and debug logging

- Added `QUICK-REFERENCE.md`
  - Complete input types table
  - Panel UI components and layout containers
  - Minimal working plugin example with `fiftyone.yml`

### Updated files

- Updated `SKILL.md`
  - Added TL;DR routing table with clear “Read NOW” directives
  - Fixed `Panel | Hybrid (default)` → `Python-only (default)`
  - Added directive to test complex logic outside the plugin first
  - Reduced file size from 638 to 434 lines by moving reference content into sub-files

- Updated `PYTHON-PANEL.md`
  - Added “How Panels Work” mental model
  - Fixed `on_change_selection` → `on_change_selected`
  - Fixed invalid `GridView` kwargs
  - Added state anti-patterns section
  - Added Plotly click-to-filter example
  - Added dense layout example

- Updated `PYTHON-OPERATOR.md`
  - Added “How Operators Work” mental model
  - Added missing input types: `uploaded_file()`, nested `obj()`, and `map()`
  - Added `fiftyone.yml` to the complete example

- Updated `EXECUTION-STORE.md` and `HYBRID-PLUGINS.md`
  - Replaced private API usage `ctx.dataset._doc.id` with stable public property `ctx.dataset.name`

## Findings addressed

| Finding | Description | Fix |
|---|---|---|
| F1 | Plugin not rendering is the number 1 stuck point | Added one-shot diagnostic and troubleshooting guide |
| F2 | Agents only read `SKILL.md`, not sub-files | Added explicit “Read NOW” routing directives |
| F3 | State management anti-patterns | Added panel state anti-patterns section |
| F4 | Layout defaults to vertical stacking | Added layout guidance and dense examples |
| F5 | App reload vs restart confusion | Added reload vs restart table |
| F6 | Instructions too verbose to start | Added TL;DR routing table |
| F7 | MCP not detected / App not running | Added pre-flight checks |
| F8 | Input types reference incomplete | Added complete quick-reference tables |
| F10 | Session and dataset lifecycle undocumented | Added app lifecycle section |
