### PR TITLE
update zoo skill for setter config pattern

### DIFF
--- a/skills/fiftyone-zoo-remote-model/SKILL.md
+++ b/skills/fiftyone-zoo-remote-model/SKILL.md
@@ -60,6 +60,7 @@ Copy `template/`:
 
 Canonical names; other files cite by name. Full failure modes and diagnostic moves in [DEBUGGING-PRINCIPLES.md](references/DEBUGGING-PRINCIPLES.md).
 
+- **Runtime parameters are setters.** NEVER make users reconstruct the model to change a `generate()` / forward kwarg, a prompt, an operation selector, or a post-processing threshold. *Why:* weights are large; anything that feeds into `model(...)` is per-call input, not model identity.
 - **Framework-first.** ALWAYS use FiftyOne primitives before custom code. *Why:* framework classes are worker-importable; yours aren't.
 - **Worker-pickle constraint.** NEVER define pickle-bound objects in `zoo.py`. *Why:* spawned DataLoader workers can't import modules loaded via `importlib.util.spec_from_file_location`.
 - **Reference implementations need verification.** NEVER copy a pattern from another zoo source without running it under multi-worker first. *Why:* widely-copied references silently break.

--- a/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
+++ b/skills/fiftyone-zoo-remote-model/references/MODEL-CLASS.md
@@ -97,3 +97,45 @@ def predict_all(self, batch, samples=None):
 ```
 
 If you don't want the dict convenience, drop the `isinstance` check entirely and assume `PIL.Image`.
+
+## Runtime parameters as setters
+
+Every parameter a user might change between calls should be a `@property` + `@<name>.setter` on the model class — not a construction-only argument. Without this, users must reconstruct the model to change anything, which reloads the (often multi-GB) weights on the next inference call.
+
+### The heuristic
+
+If the parameter is passed to `self._model(...)`, `self._model.generate(...)`, or any post-processing step the model class applies to the raw output, it is a *runtime parameter* and should be a setter. If it changes what gets loaded (weight file, dtype, device, architecture variant), it is *construction-only* and reload is unavoidable.
+
+| Category | Setter? |
+|---|---|
+| Model identity (`model_path`, architecture variant) | No |
+| Precision / placement (`torch_dtype`, `device`) | No |
+| Per-call inputs that build the forward call (prompts, class lists, schemas, tool definitions) | Yes |
+| Generation / decoding params (`max_new_tokens`, `temperature`, `do_sample`, `top_p`, `top_k`, `repetition_penalty`, beam width, ...) | Yes |
+| Operation / task / mode selectors that pick a prompt template or post-processor | Yes (validate against the allowed set) |
+| Post-processing thresholds (`confidence_threshold`, `iou_threshold`, `max_detections`) | Yes |
+| Framework contracts (`transforms`, `ragged_batches`, `has_collate_fn`, `build_get_item`, `collate_fn`) | No — fixed by contract |
+| `media_type` | No when fixed by a leaf class; Yes when one class handles both |
+
+### Pattern
+
+Pick one storage location and use it consistently across the project — `self.config.X` matches most FiftyOne reference integrations; `self._X` matches some others. Internal code (`predict_all`, `_run_inference`, `_generate`, etc.) reads from that storage directly. **Setters are an external API only**; do not call `self.X = value` from your own helpers — it adds confusion without benefit.
+
+```python
+@property
+def operation(self) -> str:
+    return self.config.operation
+
+@operation.setter
+def operation(self, value: str) -> None:
+    if value not in VALID_OPERATIONS:
+        raise ValueError(
+            f"Invalid operation '{value}'. "
+            f"Must be one of {sorted(VALID_OPERATIONS)}"
+        )
+    self.config.operation = value
+```
+
+Validating setters re-use the same check that `Config.__init__` performs — extract a module-level `VALID_X` constant so both sites share one source of truth and cannot drift. Pass-through setters assign the value as-is; **do not wrap with `int()` / `float()` / `bool()` coercions**. Silent coercion has surprising edges (`bool("False")` is `True`, `int("8")` accepts strings, `int(8.9)` truncates); let the user supply the right type and fail loudly on real mistakes.
+
+Weights survive any number of setter mutations because the only thing changing is a field on `self.config` (or `self._X`); `self._model` is untouched. Reloading is required only when one of the construction-only parameters changes.


### PR DESCRIPTION
## Related Issues

<!-- Link issues with keywords: "Closes #123" or "Fixes #123" -->

N/A

## What does this PR do?

<!-- 1-2 sentence description of the change -->

Updates the `fiftyone-zoo-remote-model` to include setters pattern for model configuration, so that mutations/changes to configuration won't require loading a new model instance, but instead modify the model configuration in place. This was feedback from @harpreetsahota204 on how to improve the `LocateAnything` Remote Zoo Model integration.

## Type of Change

- [ ] New skill
- [x] Skill improvement (bug fix, better instructions, edge cases)
- [ ] New agent integration
- [ ] Documentation / repo infrastructure
- [ ] Other

## Skill Checklist

<!-- Complete this section if you're adding or modifying a skill -->

- [ ] `SKILL.md` has YAML frontmatter with, `name` and `description` at least and all keys are universally valid
- [ ] Key Directives section is present (ALWAYS/NEVER rules)
- [x] Complete Workflow section with code examples at each step
- [ ] Troubleshooting section covers common failure modes
- [ ] `AGENTS.md` updated with the skill entry
- [ ] Tested end-to-end with at least one AI assistant
- [x] `node scripts/validate-template.mjs` passes

## Testing

<!-- How did you test this? Which AI assistant(s) did you use? -->

Modifications were written by Claude Code after iterating on the `LocateAnything` remote model integration to use setter pattern for configuration changes.
